### PR TITLE
Fix most issues with line continuations

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -56,6 +56,7 @@ module.exports = grammar({
     $._integer_literal,
     $._float_literal,
     $._boz_literal,
+    $.string_literal,
     $._end_of_statement
   ],
 
@@ -1485,23 +1486,6 @@ module.exports = grammar({
       $._integer_literal,
       $._float_literal,
       $._boz_literal
-    ),
-
-    string_literal: $ => choice(
-      $._double_quoted_string,
-      $._single_quoted_string
-    ),
-
-    _double_quoted_string: $ => token(seq(
-      '"',
-      repeat(choice(/[^"\n]/, /""./, /.""/, /& *\n *&/)),
-      '"')
-    ),
-
-    _single_quoted_string: $ => token(seq(
-      "'",
-      repeat(choice(/[^'\n]/, /''./, /.''/, /& *\n *&/)),
-      "'")
     ),
 
     boolean_literal: $ => token(seq(

--- a/grammar.js
+++ b/grammar.js
@@ -55,7 +55,8 @@ module.exports = grammar({
     $._line_continuation,
     $._integer_literal,
     $._float_literal,
-    $._boz_literal
+    $._boz_literal,
+    $._end_of_statement
   ],
 
   extras: $ => [
@@ -1551,8 +1552,6 @@ module.exports = grammar({
     _semicolon: $ => ';',
 
     _newline: $ => '\n',
-
-    _end_of_statement: $ => choice($._semicolon, $._newline)
   }
 })
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10108,99 +10108,6 @@
         }
       ]
     },
-    "string_literal": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_double_quoted_string"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_single_quoted_string"
-        }
-      ]
-    },
-    "_double_quoted_string": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "\""
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "[^\"\\n]"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "\"\"."
-                },
-                {
-                  "type": "PATTERN",
-                  "value": ".\"\""
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "& *\\n *&"
-                }
-              ]
-            }
-          },
-          {
-            "type": "STRING",
-            "value": "\""
-          }
-        ]
-      }
-    },
-    "_single_quoted_string": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "'"
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "[^'\\n]"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "''."
-                },
-                {
-                  "type": "PATTERN",
-                  "value": ".''"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "& *\\n *&"
-                }
-              ]
-            }
-          },
-          {
-            "type": "STRING",
-            "value": "'"
-          }
-        ]
-      }
-    },
     "boolean_literal": {
       "type": "TOKEN",
       "content": {
@@ -10588,6 +10495,10 @@
     {
       "type": "SYMBOL",
       "name": "_boz_literal"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "string_literal"
     },
     {
       "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10467,19 +10467,6 @@
     "_newline": {
       "type": "STRING",
       "value": "\n"
-    },
-    "_end_of_statement": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_semicolon"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_newline"
-        }
-      ]
     }
   },
   "extras": [
@@ -10601,6 +10588,10 @@
     {
       "type": "SYMBOL",
       "name": "_boz_literal"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_end_of_statement"
     }
   ],
   "inline": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2849,11 +2849,6 @@
     }
   },
   {
-    "type": "filename",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "forall_statement",
     "named": true,
     "fields": {},
@@ -6067,11 +6062,6 @@
     }
   },
   {
-    "type": "string_literal",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "submodule",
     "named": true,
     "fields": {},
@@ -7688,6 +7678,10 @@
     "named": false
   },
   {
+    "type": "filename",
+    "named": true
+  },
+  {
     "type": "final",
     "named": false
   },
@@ -7809,11 +7803,11 @@
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "nopass",
@@ -7970,6 +7964,10 @@
   {
     "type": "stop",
     "named": false
+  },
+  {
+    "type": "string_literal",
+    "named": true
   },
   {
     "type": "submodule",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -7809,11 +7809,11 @@
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -7803,11 +7803,11 @@
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "nopass",

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -239,7 +239,7 @@ struct Scanner {
       advance(lexer);
       lexer->result_symbol = STRING_LITERAL;
 
-      while (lexer->lookahead != '\n') {
+      while (lexer->lookahead != '\n' && !lexer->eof(lexer)) {
         // Handle line continuations: strictly speaking, we MUST have
         // both trailing '&' on first line AND leading '&' on second
         // line, though most compilers do accept string literals

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,25 +1,28 @@
 #include <cctype>
-#include <tree_sitter/parser.h>
+#include "tree_sitter/parser.h"
 #include <string>
 #include <cwctype>
+#include <cstring>
 
 namespace {
 
 using std::wstring;
-using std::isalpha;
 using std::iswalnum;
 using std::iswdigit;
-using std::iswxdigit;
 using std::iswspace;
 
 enum TokenType {
     _LINE_CONTINUATION,
     _INTEGER_LITERAL,
     _FLOAT_LITERAL,
-    _BOZ_LITERAL
+    _BOZ_LITERAL,
+    _END_OF_STATEMENT
 };
 
 struct Scanner {
+    // Was the last non-blank, non-comment a line continuation?
+    bool in_line_continuation = false;
+
     //  consume current character into current token and advance
     void advance(TSLexer *lexer) {
       lexer->advance(lexer, false);
@@ -151,10 +154,104 @@ struct Scanner {
         }
     }
 
+    bool scan_end_of_statement(TSLexer *lexer) {
+        // Things that end statements in Fortran:
+        //
+        // - semicolons
+        // - end-of-line (various representations)
+        // - comments
+        //
+        // Comments are a bit surprising, but it turns out to be
+        // easier to handle line continuations if comments consume the
+        // newline
+
+        // Semicolons and EOF always end the statement
+        if (lexer->lookahead == ';' || lexer->eof(lexer)) {
+          skip(lexer);
+          lexer->result_symbol = _END_OF_STATEMENT;
+          return true;
+        }
+
+        // If we're in a line continuation, then don't end the statement
+        if (in_line_continuation) return false;
+
+        // Consume end of line characters, we allow '\n', '\r\n' and
+        // '\r' to cover unix, MSDOS and old style Macintosh.
+        // Handle comments here too, but don't consume them
+        if (lexer->lookahead == '\r') {
+          skip(lexer);
+          if (lexer->lookahead == '\n') {
+              skip(lexer);
+          }
+        } else {
+          if (lexer->lookahead == '\n') {
+            skip(lexer);
+          } else if (lexer->lookahead != '!') {
+            // Not a newline and not a comment, so not an
+            // end-of-statement
+            return false;
+          }
+        }
+
+        lexer->result_symbol = _END_OF_STATEMENT;
+        return true;
+    }
+
+    bool scan_start_line_continuation(TSLexer *lexer) {
+      // Now see if we should start a line continuation
+      in_line_continuation = (lexer->lookahead == '&');
+      if (!in_line_continuation) {
+        return false;
+      }
+      // Consume the '&'
+      advance(lexer);
+      lexer->result_symbol = _LINE_CONTINUATION;
+      return true;
+    }
+
+    bool scan_end_line_continuation(TSLexer *lexer) {
+      if (!in_line_continuation) {
+        return false;
+      }
+      // Everything except comments ends a line continuation
+      if (lexer->lookahead == '!') {
+        return false;
+      }
+
+      in_line_continuation = false;
+
+      // Consume any leading line continuation markers
+      if (lexer->lookahead == '&') {
+        advance(lexer);
+      }
+      lexer->result_symbol = _LINE_CONTINUATION;
+      return true;
+    }
+
     bool scan(TSLexer *lexer, const bool *valid_symbols) {
+        // Consume any leading whitespace except newlines
+        while (std::iswblank(lexer->lookahead)) {
+          skip(lexer);
+        }
+
+        // Close the current statement if we can
+        if (valid_symbols[_END_OF_STATEMENT]) {
+            if (scan_end_of_statement(lexer)) {
+                return true;
+            }
+        }
+
+        // We're now either in a line continuation or between
+        // statements, so we should eat all whitespace including
+        // newlines, until we come to something more interesting
         while (iswspace(lexer->lookahead)) {
             skip(lexer);
         }
+
+        if (scan_end_line_continuation(lexer)) {
+          return true;
+        }
+
         if (valid_symbols[_INTEGER_LITERAL] || valid_symbols[_FLOAT_LITERAL] || valid_symbols[_BOZ_LITERAL]) {
             // extract out root number from expression
             if (scan_number(lexer)) {
@@ -165,45 +262,11 @@ struct Scanner {
             }
         }
 
-        // always check for line cont. if nothing else found
-        lexer->result_symbol = _LINE_CONTINUATION;
-
-        // Consume '&' at the end of the line
-        if (lexer->lookahead != '&') {
-            return false;
-        }
-        advance(lexer);
-
-        // Allow whitespace after line continuation
-        while (lexer->lookahead == ' ') {
-          skip(lexer);
+        if (scan_start_line_continuation(lexer)) {
+          return true;
         }
 
-        // Allow comments after line continuation
-        if (lexer->lookahead == '!') return true;
-
-        // Consume end of line characters, we allow '\n', '\r\n' and
-        // '\r' to cover unix, MSDOS and old style Macintosh
-        if (lexer->lookahead == '\r') {
-          lexer->advance(lexer, false);
-          if (lexer->lookahead == '\n') {
-              advance(lexer);
-          }
-        }
-        else {
-          if (lexer->lookahead != '\n') return false;
-          advance(lexer);
-        }
-
-        // in some instances a second ampersand exists, on the following line
-        // I assume this is to allow the code to compile properly as free form
-        // or fixed form (i.e. put the first ampersand past column 72 and the
-        // second in column 6)
-        while (iswspace(lexer->lookahead)) {
-          advance(lexer);
-        }
-        if (lexer->lookahead == '&') advance(lexer);
-        return true;
+        return false;
     }
 };
 
@@ -222,10 +285,15 @@ bool tree_sitter_fortran_external_scanner_scan(void *payload, TSLexer *lexer,
 }
 
 unsigned tree_sitter_fortran_external_scanner_serialize(void *payload, char *buffer) {
-  return 0;
+  Scanner *scanner = static_cast<Scanner *>(payload);
+  size_t size = sizeof(bool);
+  std::memcpy(buffer, &scanner->in_line_continuation, size);
+  return size;
 }
 
 void tree_sitter_fortran_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
+  Scanner *scanner = static_cast<Scanner *>(payload);
+  std::memcpy(&scanner->in_line_continuation, buffer, length);
 }
 
 void tree_sitter_fortran_external_scanner_destroy(void *payload) {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -68,9 +68,9 @@ String Literals
 
 PROGRAM TEST
     sngl_qt = ''
-    sngl_qt = '123456789!<>/?@#$%"\\"//abcdefgh''ABCDEFGH'
+    sngl_qt = '123456789!<>/?@#$%&"\\"//abcdefgh''ABCDEFGH'
     dble_qt = ""
-    dble_qt = "123456789!<>/?@#$%'\\'//abcdefgh""ABCDEFGH"
+    dble_qt = "123456789!<>/?@#$%&'\\'//abcdefgh""ABCDEFGH"
     dble_qt = """double double quotes"""
     sngl_qt = '''double single quotes'''
     dble_qt = "'single in double quotes'"

--- a/test/corpus/line_continuations.txt
+++ b/test/corpus/line_continuations.txt
@@ -157,3 +157,24 @@ end program ! comment
     (end_program_statement))
   (comment)
   (comment))
+
+============================================
+Line continuation in concat string
+============================================
+
+program test
+  print*, "12&bar"
+  print*, "&
+    &hello"
+end program
+
+---
+
+(translation_unit
+  (program
+    (program_statement (name))
+    (print_statement (format_identifier)
+      (output_item_list (string_literal)))
+    (print_statement (format_identifier)
+      (output_item_list (string_literal)))
+    (end_program_statement)))

--- a/test/corpus/line_continuations.txt
+++ b/test/corpus/line_continuations.txt
@@ -1,0 +1,159 @@
+============================================
+Comment followed by line continuation
+============================================
+
+program test
+    write(*, "('Testing line continuation')", &
+       &  advance='no', &  ! Comment after line continuation
+       &  iostat=istat)
+end program
+
+---
+
+(translation_unit
+  (program
+    (program_statement (name))
+    (write_statement
+      (unit_identifier)
+      (format_identifier (string_literal))
+      (keyword_argument (identifier) (string_literal))
+      (comment)
+      (keyword_argument (identifier) (identifier)))
+    (end_program_statement)))
+
+============================================
+Line continuations with comment and blank lines
+============================================
+
+program test
+    write(*, "('Testing line continuation')", &
+       ! comment
+       &  advance='no', &
+
+
+       &  iostat=istat  &
+
+
+       )
+end program
+
+---
+
+(translation_unit
+  (program
+    (program_statement (name))
+    (write_statement
+      (unit_identifier)
+      (format_identifier (string_literal))
+      (comment)
+      (keyword_argument (identifier) (string_literal))
+      (keyword_argument (identifier) (identifier)))
+    (end_program_statement)))
+
+============================================
+Line continuation before comma
+============================================
+
+program test
+  integer :: foo & ! comment
+    , bar
+end program test
+
+---
+
+(translation_unit
+  (program
+    (program_statement (name))
+    (variable_declaration
+      (intrinsic_type)
+      (identifier) (comment) (identifier))
+    (end_program_statement (name))))
+
+============================================
+Line continuation before function suffix
+============================================
+
+program test
+contains
+  function foo( &
+    bar) &  ! comment
+  result(res)
+    integer :: bar
+  end function foo
+end program test
+
+----
+
+(translation_unit
+  (program
+    (program_statement (name))
+    (internal_procedures
+      (contains_statement)
+      (function
+        (function_statement (name)
+          (parameters (identifier))
+          (comment)
+          (function_result (identifier)))
+        (variable_declaration (intrinsic_type) (identifier))
+        (end_function_statement (name))))
+ (end_program_statement (name))))
+
+
+============================================
+Empty Write with FMT
+============================================
+
+program test
+    write(*, 1)
+
+1  format('hello')
+end program
+
+---
+
+(translation_unit
+  (program
+    (program_statement (name))
+    (write_statement
+      (unit_identifier)
+      (format_identifier (statement_label_reference)))
+    (statement_label)
+    (format_statement
+      (transfer_items (string_literal)))
+    (end_program_statement)))
+
+============================================
+Inline comments
+============================================
+
+!comment
+PROGRAM TEST
+    int_val = 1     ! comment
+    int_val = 1_SZ1 ! comment
+contains ! comment
+   subroutine foo() ! comment
+   end subroutine foo ! comment
+end program ! comment
+! comment
+
+---
+
+(translation_unit
+  (comment)
+  (program
+    (program_statement (name))
+    (assignment_statement (identifier) (number_literal))
+    (comment)
+    (assignment_statement (identifier) (number_literal))
+    (comment)
+    (internal_procedures
+      (contains_statement)
+      (comment)
+      (subroutine
+        (subroutine_statement (name))
+        (comment)
+        (end_subroutine_statement (name))))
+        (comment)
+    (end_program_statement))
+  (comment)
+  (comment))


### PR DESCRIPTION
End-of-statements are now handled in the external scanner, which allows us to use a bit more logic than the DSL rules allow.

Logic of external scanner now goes like:

1. skip all leading whitespace
2. work out if we should end the current statement
3. work out if we should end the current line continuation
4. handle number literals
5. possibly start a new line continuation

Statements are always ended by semicolons and end-of-file, and _may_ be ended by newlines unless a line continuation has started.

Because comments always go to the end of the line, and may appear inside line continuations, it turns out to be easier to treat comments as also ending statements -- unless they appear inside a line continuation.

Line continuations now are essentially always in pairs marking the start and end of the continuation, possibly with comments in-between.

Deals with most of #80 