### PR TITLE
More f77 features

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -89,6 +89,7 @@ module.exports = grammar({
     [$.elsewhere_clause],
     [$.interface_statement],
     [$.intrinsic_type, $.identifier],
+    [$.inquire_statement, $.identifier],
     [$.module_statement, $.procedure_qualifier],
     [$.procedure_declaration],
     [$.rank_statement],
@@ -749,6 +750,7 @@ module.exports = grammar({
       $.print_statement,
       $.write_statement,
       $.read_statement,
+      $.inquire_statement,
       $.stop_statement,
       $.block_construct,
       $.associate_statement,
@@ -1201,6 +1203,18 @@ module.exports = grammar({
 
     edit_descriptor: $ => /[a-zA-Z0-9/:.*$]+/,
 
+    _io_arguments: $ => seq(
+      '(',
+      choice(
+        $.unit_identifier,
+        seq($.unit_identifier, ',', $.format_identifier),
+        seq($.unit_identifier, ',', $.format_identifier, ',', commaSep1($.keyword_argument)),
+        seq($.unit_identifier, ',', commaSep1($.keyword_argument)),
+        commaSep1($.keyword_argument)
+      ),
+      ')'
+    ),
+
     read_statement: $ => prec(1, choice(
       $._simple_read_statement,
       $._parameterized_read_statement
@@ -1214,15 +1228,7 @@ module.exports = grammar({
 
     _parameterized_read_statement: $ => prec(1, seq(
       caseInsensitive('read'),
-      '(',
-      choice(
-        $.unit_identifier,
-        seq($.unit_identifier, ',', $.format_identifier),
-        seq($.unit_identifier, ',', $.format_identifier, ',', commaSep1($.keyword_argument)),
-        seq($.unit_identifier, ',', commaSep1($.keyword_argument)),
-        commaSep1($.keyword_argument)
-      ),
-      ')',
+      $._io_arguments,
       optional($.input_item_list)
     )),
 
@@ -1234,15 +1240,7 @@ module.exports = grammar({
 
     open_statement: $ => seq(
       caseInsensitive('open'),
-      '(',
-      choice(
-        $.unit_identifier,
-        seq($.unit_identifier, ',', $.format_identifier),
-        seq($.unit_identifier, ',', $.format_identifier, ',', commaSep1($.keyword_argument)),
-        seq($.unit_identifier, ',', commaSep1($.keyword_argument)),
-        commaSep1($.keyword_argument)
-      ),
-      ')',
+      $._io_arguments,
       optional($.output_item_list)
     ),
 
@@ -1260,18 +1258,16 @@ module.exports = grammar({
 
     write_statement: $ => prec(1, seq(
       caseInsensitive('write'),
-      '(',
-      choice(
-        $.unit_identifier,
-        seq($.unit_identifier, ',', $.format_identifier),
-        seq($.unit_identifier, ',', $.format_identifier, ',', commaSep1($.keyword_argument)),
-        seq($.unit_identifier, ',', commaSep1($.keyword_argument)),
-        commaSep1($.keyword_argument)
-      ),
-      ')',
+      $._io_arguments,
       // Trailing comma here is a legacy extension to gfortran
       optional(','),
       optional($.output_item_list)
+    )),
+
+    inquire_statement: $ => prec(1, seq(
+      caseInsensitive('inquire'),
+      $._io_arguments,
+      optional($.output_item_list),
     )),
 
     enum: $ => seq(
@@ -1588,6 +1584,7 @@ module.exports = grammar({
       caseInsensitive('error'),
       caseInsensitive('exit'),
       caseInsensitive('if'),
+      caseInsensitive('inquire'),
       caseInsensitive('read'),
       caseInsensitive('real'),
       caseInsensitive('select'),

--- a/grammar.js
+++ b/grammar.js
@@ -1201,6 +1201,7 @@ module.exports = grammar({
     _transfer_item: $ => choice(
       $.string_literal,
       $.edit_descriptor,
+      $.hollerith_constant,
       seq('(', $._transfer_items, ')')
     ),
 
@@ -1211,7 +1212,9 @@ module.exports = grammar({
       repeat(seq(optional(','), $._transfer_item))
     ),
 
-    edit_descriptor: $ => /[a-zA-Z0-9/:.*$]+/,
+    // H is not a valid edit descriptor because it clashes with Hollerith constants
+    edit_descriptor: $ => /[a-gi-zA-GI-Z0-9/:.*$]+/,
+    hollerith_constant: $ => prec.right(10, /[0-9]+H[^/,)]+/),
 
     _io_arguments: $ => seq(
       '(',

--- a/grammar.js
+++ b/grammar.js
@@ -1192,7 +1192,7 @@ module.exports = grammar({
       repeat(seq(optional(','), $._transfer_item))
     ),
 
-    edit_descriptor: $ => /[a-zA-Z0-9/:.*]+/,
+    edit_descriptor: $ => /[a-zA-Z0-9/:.*$]+/,
 
     read_statement: $ => prec(1, choice(
       $._simple_read_statement,

--- a/grammar.js
+++ b/grammar.js
@@ -848,6 +848,7 @@ module.exports = grammar({
             alias(caseInsensitive('null'), $.null_literal),
             '(', ')'
           ),
+          $.identifier,
           $.call_expression
         )
       )),

--- a/grammar.js
+++ b/grammar.js
@@ -1566,6 +1566,7 @@ module.exports = grammar({
     // add the keywords here -- and possibly in `conflicts` too.
     identifier: $ => choice(
       /[a-zA-Z_]\w*/,
+      caseInsensitive('block'),
       caseInsensitive('byte'),
       caseInsensitive('cycle'),
       caseInsensitive('data'),

--- a/grammar.js
+++ b/grammar.js
@@ -92,6 +92,7 @@ module.exports = grammar({
     [$.intrinsic_type, $.identifier],
     [$.inquire_statement, $.identifier],
     [$.module_statement, $.procedure_qualifier],
+    [$.null_literal, $.identifier],
     [$.procedure_declaration],
     [$.rank_statement],
     [$.stop_statement, $.identifier],
@@ -526,7 +527,7 @@ module.exports = grammar({
     procedure_statement: $ => seq(
       $._procedure_kind,
       optional(seq(
-        '(', alias($.identifier,$.procedure_interface),')'
+        '(', alias($.identifier, $.procedure_interface), ')'
       )),
       optional(seq(
         ',',
@@ -536,7 +537,7 @@ module.exports = grammar({
         seq('::', $.binding_name, '=>'),
         '::'
       )),
-      commaSep1($._method_name)
+      commaSep1($._method_name),
     ),
 
     binding_name: $ => choice(
@@ -578,7 +579,7 @@ module.exports = grammar({
     procedure_declaration: $ => seq(
       caseInsensitive('procedure'),
       optional(seq(
-        '(', alias($.identifier, $.procedure_interface), ')'
+        '(', optional(alias($.identifier, $.procedure_interface)), ')'
       )),
       optional(seq(',', commaSep1($.procedure_attribute))),
     ),
@@ -849,10 +850,7 @@ module.exports = grammar({
           $.string_literal,
           $.boolean_literal,
           $.unary_expression,
-          seq(
-            alias(caseInsensitive('null'), $.null_literal),
-            '(', ')'
-          ),
+          $.null_literal,
           $.identifier,
           $.call_expression
         )
@@ -1359,6 +1357,7 @@ module.exports = grammar({
       $.string_literal,
       $.boolean_literal,
       $.array_literal,
+      $.null_literal,
       $.identifier,
       $.derived_type_member_expression,
       $.logical_expression,
@@ -1572,6 +1571,10 @@ module.exports = grammar({
       optional(seq('_', /\w+/))
     )),
 
+    null_literal: $ => prec(1, seq(
+      caseInsensitive('null'), '(', ')'
+    )),
+
     // This handles files preprocessed by gfortran -E
     // Other preprocessors may use different syntax
     preproc_file_line: $ => seq(
@@ -1601,6 +1604,7 @@ module.exports = grammar({
       caseInsensitive('format'),
       caseInsensitive('if'),
       caseInsensitive('inquire'),
+      caseInsensitive('null'),
       caseInsensitive('read'),
       caseInsensitive('real'),
       caseInsensitive('select'),

--- a/grammar.js
+++ b/grammar.js
@@ -737,6 +737,7 @@ module.exports = grammar({
       $.keyword_statement,
       $.include_statement,
       $.if_statement,
+      $.arithmetic_if_statement,
       $.where_statement,
       $.forall_statement,
       $.select_case_statement,
@@ -939,10 +940,20 @@ module.exports = grammar({
       $._block_if_statement
     ),
 
-    _inline_if_statement: $ => prec.right(seq(
+    _inline_if_statement: $ => prec.right(2, seq(
       caseInsensitive('if'),
       $.parenthesized_expression,
       $._statements
+    )),
+
+    arithmetic_if_statement: $ => prec.right(seq(
+      caseInsensitive('if'),
+      $.parenthesized_expression,
+      $.statement_label_reference,
+      ',',
+      $.statement_label_reference,
+      ',',
+      $.statement_label_reference,
     )),
 
     _block_if_statement: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -803,10 +803,10 @@ module.exports = grammar({
       seq(
         whiteSpacedKeyword('go', 'to'),
         choice(
-          $.statement_label,
+          $.statement_label_reference,
           // Computed goto (obsolete)
           seq(
-            '(', commaSep1($.statement_label), ')',
+            '(', commaSep1($.statement_label_reference), ')',
             optional(','),
             $._expression,
           )

--- a/grammar.js
+++ b/grammar.js
@@ -355,12 +355,12 @@ module.exports = grammar({
       ',',
       caseInsensitive('only'),
       ':',
-      commaSep1(
+      optional(commaSep1(
         choice(
           $.use_alias,
           $.identifier,
           $._generic_procedure)
-      )
+      ))
     ),
 
     use_alias: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -784,9 +784,18 @@ module.exports = grammar({
       caseInsensitive('continue'),
       seq(caseInsensitive('cycle'), optional($.identifier)),
       seq(caseInsensitive('exit'), optional($.identifier)),
-      seq(whiteSpacedKeyword('go', 'to'), $.statement_label),
+      seq(
+        whiteSpacedKeyword('go', 'to'),
+        choice(
+          $.statement_label,
+          // Computed goto (obsolete)
+          seq(
+            '(', commaSep1($.statement_label), ')',
+            $.identifier,
+          )
+        )
+      ),
       caseInsensitive('return'),
-      // seq(caseInsensitive('stop'), optional($._expression))
     ),
 
     include_statement: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -804,7 +804,7 @@ module.exports = grammar({
           seq(
             '(', commaSep1($.statement_label), ')',
             optional(','),
-            $.identifier,
+            $._expression,
           )
         )
       ),

--- a/grammar.js
+++ b/grammar.js
@@ -635,7 +635,11 @@ module.exports = grammar({
       seq('*', choice(/\d+/, $.parenthesized_expression))
     ),
 
-    character_length: $ => seq('*', /\d+/),
+    character_length: $ => seq(
+      '*',
+      optional(/\d+/),
+      optional(seq('(', '*', ')'))
+    ),
 
     type_qualifier: $ => choice(
       caseInsensitive('abstract'),

--- a/grammar.js
+++ b/grammar.js
@@ -95,24 +95,28 @@ module.exports = grammar({
     [$.stop_statement, $.identifier],
     [$.type_qualifier, $.identifier],
     [$.type_statement],
+    [$.translation_unit],
   ],
 
   rules: {
-    translation_unit: $ => repeat($._top_level_item),
+    translation_unit: $ => seq(
+      repeat($._top_level_item),
+      optional($.program),
+    ),
 
-    _top_level_item: $ => choice(
+    _top_level_item: $ => prec(2, choice(
       $.program,
       $.module,
       $.submodule,
       $.interface,
       $.subroutine,
       $.function
-    ),
+    )),
 
     // Block level structures
 
     program: $ => seq(
-      $.program_statement,
+      optional($.program_statement),
       repeat($._specification_part),
       repeat($._statement),
       optional($.internal_procedures),
@@ -255,14 +259,14 @@ module.exports = grammar({
     ),
 
     _callable_interface_qualifers: $ => repeat1(
-      choice(
+      prec.right(1, choice(
         $.procedure_attributes,
         $.procedure_qualifier,
         $._intrinsic_type,
         $.derived_type
-      )),
+      ))),
 
-    procedure_attributes: $ => seq(
+    procedure_attributes: $ => prec(1, seq(
       caseInsensitive('attributes'),
       '(',
       commaSep1(choice(
@@ -271,7 +275,7 @@ module.exports = grammar({
         caseInsensitive('host'),
         caseInsensitive('grid_global'))),
       ')'
-    ),
+    )),
 
     end_function_statement: $ => blockStructureEnding($, 'function'),
 
@@ -309,7 +313,7 @@ module.exports = grammar({
 
     // Variable Declarations
 
-    _specification_part: $ => choice(
+    _specification_part: $ => prec(1, choice(
       prec(1, seq($.include_statement, $._end_of_statement)),
       seq($.use_statement, $._end_of_statement),
       seq($.implicit_statement, $._end_of_statement),
@@ -328,7 +332,7 @@ module.exports = grammar({
       seq($.equivalence_statement, $._end_of_statement),
       seq($.data_statement, $._end_of_statement),
       prec(1, seq($.statement_label, $.format_statement, $._end_of_statement))
-    ),
+    )),
 
     use_statement: $ => seq(
       caseInsensitive('use'),

--- a/grammar.js
+++ b/grammar.js
@@ -828,6 +828,7 @@ module.exports = grammar({
         optional(prec(1, seq(field('repeat', $.number_literal), '*'))),
         choice(
           $.number_literal,
+          $.complex_literal,
           $.string_literal,
           $.boolean_literal,
           $.unary_expression,

--- a/grammar.js
+++ b/grammar.js
@@ -597,6 +597,8 @@ module.exports = grammar({
 
     _declaration_targets: $ => commaSep1(choice(
       $.identifier,
+      // Only valid for characters
+      prec.right(1, seq($.identifier, $.character_length)),
       $.call_expression,
       $.assignment_statement,
       $.pointer_association_statement
@@ -632,6 +634,8 @@ module.exports = grammar({
       seq(optional(alias('*', $.assumed_size)), $.argument_list),
       seq('*', choice(/\d+/, $.parenthesized_expression))
     ),
+
+    character_length: $ => seq('*', /\d+/),
 
     type_qualifier: $ => choice(
       caseInsensitive('abstract'),

--- a/grammar.js
+++ b/grammar.js
@@ -803,6 +803,7 @@ module.exports = grammar({
           // Computed goto (obsolete)
           seq(
             '(', commaSep1($.statement_label), ')',
+            optional(','),
             $.identifier,
           )
         )

--- a/grammar.js
+++ b/grammar.js
@@ -396,8 +396,11 @@ module.exports = grammar({
     save_statement: $ => prec(1, seq(
       caseInsensitive('save'),
       optional(seq(
-        '::',
-        commaSep1($.identifier)
+        optional('::'),
+        commaSep1(choice(
+          $.identifier,
+          seq('/', $.identifier, '/'),
+        )),
       ))
     )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -1300,7 +1300,10 @@ module.exports = grammar({
       optional('::'),
       commaSep1(choice(
         $.identifier,
-        seq($.identifier, '=', $.number_literal)
+        seq($.identifier, '=', choice(
+          $.number_literal,
+          $.unary_expression,
+        ))
       ))
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -87,6 +87,7 @@ module.exports = grammar({
     [$.elseif_clause],
     [$.elsewhere_clause, $.identifier],
     [$.elsewhere_clause],
+    [$.format_statement, $.identifier],
     [$.interface_statement],
     [$.intrinsic_type, $.identifier],
     [$.inquire_statement, $.identifier],
@@ -1192,12 +1193,12 @@ module.exports = grammar({
       optional($._block_label)
     ),
 
-    format_statement: $ => seq(
+    format_statement: $ => prec(1, seq(
       caseInsensitive('format'),
       '(',
       alias($._transfer_items, $.transfer_items),
       ')'
-    ),
+    )),
 
     _transfer_item: $ => choice(
       $.string_literal,
@@ -1594,6 +1595,7 @@ module.exports = grammar({
       caseInsensitive('endif'),
       caseInsensitive('error'),
       caseInsensitive('exit'),
+      caseInsensitive('format'),
       caseInsensitive('if'),
       caseInsensitive('inquire'),
       caseInsensitive('read'),

--- a/grammar.js
+++ b/grammar.js
@@ -533,18 +533,18 @@ module.exports = grammar({
         ',',
         commaSep1($.procedure_attribute)
       )),
-      optional(choice(
-        seq('::', $.binding_name, '=>'),
-        '::'
+      optional('::'),
+      commaSep1(choice(
+        $.method_name,
+        seq($.binding_name, '=>', $.method_name),
       )),
-      commaSep1($._method_name),
     ),
 
     binding_name: $ => choice(
       $.identifier,
       $._generic_procedure
     ),
-    _method_name: $ => alias($.identifier, $.method_name),
+    method_name: $ => alias($.identifier, 'method_name'),
 
     _procedure_kind: $ => choice(
       caseInsensitive('generic'),

--- a/grammar.js
+++ b/grammar.js
@@ -105,6 +105,7 @@ module.exports = grammar({
     ),
 
     _top_level_item: $ => prec(2, choice(
+      seq($.include_statement, $._end_of_statement),
       $.program,
       $.module,
       $.submodule,

--- a/grammar.js
+++ b/grammar.js
@@ -867,6 +867,7 @@ module.exports = grammar({
       )),
       $._end_of_statement,
       repeat($._statement),
+      optional($.statement_label),
       $.end_do_loop_statement
     ),
 
@@ -952,6 +953,7 @@ module.exports = grammar({
       repeat($._statement),
       repeat($.elseif_clause),
       optional($.else_clause),
+      optional($.statement_label),
       $.end_if_statement
     ),
 
@@ -1045,6 +1047,7 @@ module.exports = grammar({
       $._forall_control_expression,
       $._end_of_statement,
       repeat($._statement),
+      optional($.statement_label),
       $.end_forall_statement
     ),
 
@@ -1059,6 +1062,7 @@ module.exports = grammar({
       $.selector,
       $._end_of_statement,
       repeat1($.case_statement),
+      optional($.statement_label),
       $.end_select_statement
     ),
 
@@ -1068,6 +1072,7 @@ module.exports = grammar({
       $.selector,
       $._end_of_statement,
       repeat1($.type_statement),
+      optional($.statement_label),
       $.end_select_statement
     ),
 
@@ -1077,6 +1082,7 @@ module.exports = grammar({
       $.selector,
       $._end_of_statement,
       repeat1($.rank_statement),
+      optional($.statement_label),
       $.end_select_statement
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3767,6 +3767,23 @@
               "name": "identifier"
             },
             {
+              "type": "PREC_RIGHT",
+              "value": 1,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "character_length"
+                  }
+                ]
+              }
+            },
+            {
               "type": "SYMBOL",
               "name": "call_expression"
             },
@@ -3795,6 +3812,23 @@
                   {
                     "type": "SYMBOL",
                     "name": "identifier"
+                  },
+                  {
+                    "type": "PREC_RIGHT",
+                    "value": 1,
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "identifier"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "character_length"
+                        }
+                      ]
+                    }
                   },
                   {
                     "type": "SYMBOL",
@@ -4064,6 +4098,19 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    "character_length": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "*"
+        },
+        {
+          "type": "PATTERN",
+          "value": "\\d+"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5579,6 +5579,10 @@
                     },
                     {
                       "type": "SYMBOL",
+                      "name": "identifier"
+                    },
+                    {
+                      "type": "SYMBOL",
                       "name": "call_expression"
                     }
                   ]
@@ -5675,6 +5679,10 @@
                                 "value": ")"
                               }
                             ]
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "identifier"
                           },
                           {
                             "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5251,6 +5251,18 @@
                       "value": ")"
                     },
                     {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
                       "type": "SYMBOL",
                       "name": "identifier"
                     }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7841,35 +7841,39 @@
       ]
     },
     "format_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[fF][oO][rR][mM][aA][tT]"
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "[fF][oO][rR][mM][aA][tT]"
+            },
+            "named": false,
+            "value": "format"
           },
-          "named": false,
-          "value": "format"
-        },
-        {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_transfer_items"
+          {
+            "type": "STRING",
+            "value": "("
           },
-          "named": true,
-          "value": "transfer_items"
-        },
-        {
-          "type": "STRING",
-          "value": ")"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_transfer_items"
+            },
+            "named": true,
+            "value": "transfer_items"
+          },
+          {
+            "type": "STRING",
+            "value": ")"
+          }
+        ]
+      }
     },
     "_transfer_item": {
       "type": "CHOICE",
@@ -10655,6 +10659,15 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
+            "value": "[fF][oO][rR][mM][aA][tT]"
+          },
+          "named": false,
+          "value": "format"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
             "value": "[iI][fF]"
           },
           "named": false,
@@ -10835,6 +10848,10 @@
     ],
     [
       "elsewhere_clause"
+    ],
+    [
+      "format_statement",
+      "identifier"
     ],
     [
       "interface_statement"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10597,6 +10597,15 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
+            "value": "[bB][lL][oO][cC][kK]"
+          },
+          "named": false,
+          "value": "block"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
             "value": "[bB][yY][tT][eE]"
           },
           "named": false,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2,47 +2,76 @@
   "name": "fortran",
   "rules": {
     "translation_unit": {
-      "type": "REPEAT",
-      "content": {
-        "type": "SYMBOL",
-        "name": "_top_level_item"
-      }
-    },
-    "_top_level_item": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "program"
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_top_level_item"
+          }
         },
         {
-          "type": "SYMBOL",
-          "name": "module"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "submodule"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "interface"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "subroutine"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "function"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "program"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
+    },
+    "_top_level_item": {
+      "type": "PREC",
+      "value": 2,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "program"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "module"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "submodule"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "interface"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "subroutine"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "function"
+          }
+        ]
+      }
     },
     "program": {
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "program_statement"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "program_statement"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "REPEAT",
@@ -1175,147 +1204,155 @@
     "_callable_interface_qualifers": {
       "type": "REPEAT1",
       "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "procedure_attributes"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "procedure_qualifier"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_intrinsic_type"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "derived_type"
-          }
-        ]
+        "type": "PREC_RIGHT",
+        "value": 1,
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "procedure_attributes"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "procedure_qualifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_intrinsic_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "derived_type"
+            }
+          ]
+        }
       }
     },
     "procedure_attributes": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[aA][tT][tT][rR][iI][bB][uU][tT][eE][sS]"
-          },
-          "named": false,
-          "value": "attributes"
-        },
-        {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[gG][lL][oO][bB][aA][lL]"
-                  },
-                  "named": false,
-                  "value": "global"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[dD][eE][vV][iI][cC][eE]"
-                  },
-                  "named": false,
-                  "value": "device"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[hH][oO][sS][tT]"
-                  },
-                  "named": false,
-                  "value": "host"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[gG][rR][iI][dD]_[gG][lL][oO][bB][aA][lL]"
-                  },
-                  "named": false,
-                  "value": "grid_global"
-                }
-              ]
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "[aA][tT][tT][rR][iI][bB][uU][tT][eE][sS]"
             },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
+            "named": false,
+            "value": "attributes"
+          },
+          {
+            "type": "STRING",
+            "value": "("
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
                 "members": [
                   {
-                    "type": "STRING",
-                    "value": ","
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[gG][lL][oO][bB][aA][lL]"
+                    },
+                    "named": false,
+                    "value": "global"
                   },
                   {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[gG][lL][oO][bB][aA][lL]"
-                        },
-                        "named": false,
-                        "value": "global"
-                      },
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[dD][eE][vV][iI][cC][eE]"
-                        },
-                        "named": false,
-                        "value": "device"
-                      },
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[hH][oO][sS][tT]"
-                        },
-                        "named": false,
-                        "value": "host"
-                      },
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[gG][rR][iI][dD]_[gG][lL][oO][bB][aA][lL]"
-                        },
-                        "named": false,
-                        "value": "grid_global"
-                      }
-                    ]
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[dD][eE][vV][iI][cC][eE]"
+                    },
+                    "named": false,
+                    "value": "device"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[hH][oO][sS][tT]"
+                    },
+                    "named": false,
+                    "value": "host"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[gG][rR][iI][dD]_[gG][lL][oO][bB][aA][lL]"
+                    },
+                    "named": false,
+                    "value": "grid_global"
                   }
                 ]
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "PATTERN",
+                            "value": "[gG][lL][oO][bB][aA][lL]"
+                          },
+                          "named": false,
+                          "value": "global"
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "PATTERN",
+                            "value": "[dD][eE][vV][iI][cC][eE]"
+                          },
+                          "named": false,
+                          "value": "device"
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "PATTERN",
+                            "value": "[hH][oO][sS][tT]"
+                          },
+                          "named": false,
+                          "value": "host"
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "PATTERN",
+                            "value": "[gG][rR][iI][dD]_[gG][lL][oO][bB][aA][lL]"
+                          },
+                          "named": false,
+                          "value": "grid_global"
+                        }
+                      ]
+                    }
+                  ]
+                }
               }
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": ")"
-        }
-      ]
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": ")"
+          }
+        ]
+      }
     },
     "end_function_statement": {
       "type": "PREC_RIGHT",
@@ -1515,228 +1552,232 @@
       "value": "contains"
     },
     "_specification_part": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "PREC",
-          "value": 1,
-          "content": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "include_statement"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_end_of_statement"
+                }
+              ]
+            }
+          },
+          {
             "type": "SEQ",
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "include_statement"
+                "name": "use_statement"
               },
               {
                 "type": "SYMBOL",
                 "name": "_end_of_statement"
               }
             ]
-          }
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "use_statement"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_end_of_statement"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "implicit_statement"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_end_of_statement"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "save_statement"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_end_of_statement"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "import_statement"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_end_of_statement"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "public_statement"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_end_of_statement"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "private_statement"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_end_of_statement"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "enum"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "interface"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "derived_type_definition"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "namelist_statement"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_end_of_statement"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "common_statement"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_end_of_statement"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "variable_declaration"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_end_of_statement"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "variable_modification"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_end_of_statement"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "parameter_statement"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_end_of_statement"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "equivalence_statement"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_end_of_statement"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "data_statement"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_end_of_statement"
-            }
-          ]
-        },
-        {
-          "type": "PREC",
-          "value": 1,
-          "content": {
+          },
+          {
             "type": "SEQ",
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "statement_label"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "format_statement"
+                "name": "implicit_statement"
               },
               {
                 "type": "SYMBOL",
                 "name": "_end_of_statement"
               }
             ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "save_statement"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_end_of_statement"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "import_statement"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_end_of_statement"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "public_statement"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_end_of_statement"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "private_statement"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_end_of_statement"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "enum"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "interface"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "derived_type_definition"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "namelist_statement"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_end_of_statement"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "common_statement"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_end_of_statement"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "variable_declaration"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_end_of_statement"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "variable_modification"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_end_of_statement"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "parameter_statement"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_end_of_statement"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "equivalence_statement"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_end_of_statement"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "data_statement"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_end_of_statement"
+              }
+            ]
+          },
+          {
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "statement_label"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "format_statement"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_end_of_statement"
+                }
+              ]
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "use_statement": {
       "type": "SEQ",
@@ -10824,6 +10865,9 @@
     ],
     [
       "type_statement"
+    ],
+    [
+      "translation_unit"
     ]
   ],
   "precedences": [],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5390,6 +5390,10 @@
                     },
                     {
                       "type": "SYMBOL",
+                      "name": "complex_literal"
+                    },
+                    {
+                      "type": "SYMBOL",
                       "name": "string_literal"
                     },
                     {
@@ -5482,6 +5486,10 @@
                           {
                             "type": "SYMBOL",
                             "name": "number_literal"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "complex_literal"
                           },
                           {
                             "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3318,30 +3318,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "::"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "binding_name"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "=>"
-                    }
-                  ]
-                },
-                {
-                  "type": "STRING",
-                  "value": "::"
-                }
-              ]
+              "type": "STRING",
+              "value": "::"
             },
             {
               "type": "BLANK"
@@ -3352,8 +3330,30 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_method_name"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "method_name"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "binding_name"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "=>"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "method_name"
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "REPEAT",
@@ -3365,8 +3365,30 @@
                     "value": ","
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "_method_name"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "method_name"
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "binding_name"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "=>"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "method_name"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
               }
@@ -3388,13 +3410,13 @@
         }
       ]
     },
-    "_method_name": {
+    "method_name": {
       "type": "ALIAS",
       "content": {
         "type": "SYMBOL",
         "name": "identifier"
       },
-      "named": true,
+      "named": false,
       "value": "method_name"
     },
     "_procedure_kind": {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1935,53 +1935,61 @@
           "value": ":"
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
+              "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "use_alias"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "use_alias"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_generic_procedure"
+                    }
+                  ]
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_generic_procedure"
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "use_alias"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "identifier"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_generic_procedure"
+                          }
+                        ]
+                      }
+                    ]
+                  }
                 }
               ]
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "use_alias"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "identifier"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_generic_procedure"
-                      }
-                    ]
-                  }
-                ]
-              }
+              "type": "BLANK"
             }
           ]
         }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3689,13 +3689,21 @@
                   "value": "("
                 },
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  },
-                  "named": true,
-                  "value": "procedure_interface"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      "named": true,
+                      "value": "procedure_interface"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 },
                 {
                   "type": "STRING",
@@ -5572,31 +5580,8 @@
                       "name": "unary_expression"
                     },
                     {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "ALIAS",
-                            "content": {
-                              "type": "PATTERN",
-                              "value": "[nN][uU][lL][lL]"
-                            },
-                            "named": false,
-                            "value": "null"
-                          },
-                          "named": true,
-                          "value": "null_literal"
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "("
-                        },
-                        {
-                          "type": "STRING",
-                          "value": ")"
-                        }
-                      ]
+                      "type": "SYMBOL",
+                      "name": "null_literal"
                     },
                     {
                       "type": "SYMBOL",
@@ -5675,31 +5660,8 @@
                             "name": "unary_expression"
                           },
                           {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "ALIAS",
-                                "content": {
-                                  "type": "ALIAS",
-                                  "content": {
-                                    "type": "PATTERN",
-                                    "value": "[nN][uU][lL][lL]"
-                                  },
-                                  "named": false,
-                                  "value": "null"
-                                },
-                                "named": true,
-                                "value": "null_literal"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "("
-                              },
-                              {
-                                "type": "STRING",
-                                "value": ")"
-                              }
-                            ]
+                            "type": "SYMBOL",
+                            "name": "null_literal"
                           },
                           {
                             "type": "SYMBOL",
@@ -8949,6 +8911,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "null_literal"
+        },
+        {
+          "type": "SYMBOL",
           "name": "identifier"
         },
         {
@@ -10533,6 +10499,32 @@
         ]
       }
     },
+    "null_literal": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "[nN][uU][lL][lL]"
+            },
+            "named": false,
+            "value": "null"
+          },
+          {
+            "type": "STRING",
+            "value": "("
+          },
+          {
+            "type": "STRING",
+            "value": ")"
+          }
+        ]
+      }
+    },
     "preproc_file_line": {
       "type": "SEQ",
       "members": [
@@ -10699,6 +10691,15 @@
           },
           "named": false,
           "value": "inquire"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[nN][uU][lL][lL]"
+          },
+          "named": false,
+          "value": "null"
         },
         {
           "type": "ALIAS",
@@ -10885,6 +10886,10 @@
     [
       "module_statement",
       "procedure_qualifier"
+    ],
+    [
+      "null_literal",
+      "identifier"
     ],
     [
       "procedure_declaration"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2273,15 +2273,45 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "STRING",
-                    "value": "::"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "::"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
                   },
                   {
                     "type": "SEQ",
                     "members": [
                       {
-                        "type": "SYMBOL",
-                        "name": "identifier"
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "identifier"
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "/"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "identifier"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "/"
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
                         "type": "REPEAT",
@@ -2293,8 +2323,30 @@
                               "value": ","
                             },
                             {
-                              "type": "SYMBOL",
-                              "name": "identifier"
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "identifier"
+                                },
+                                {
+                                  "type": "SEQ",
+                                  "members": [
+                                    {
+                                      "type": "STRING",
+                                      "value": "/"
+                                    },
+                                    {
+                                      "type": "SYMBOL",
+                                      "name": "identifier"
+                                    },
+                                    {
+                                      "type": "STRING",
+                                      "value": "/"
+                                    }
+                                  ]
+                                }
+                              ]
                             }
                           ]
                         }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7801,7 +7801,7 @@
     },
     "edit_descriptor": {
       "type": "PATTERN",
-      "value": "[a-zA-Z0-9/:.*]+"
+      "value": "[a-zA-Z0-9/:.*$]+"
     },
     "read_statement": {
       "type": "PREC",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5087,8 +5087,55 @@
               "value": "goto"
             },
             {
-              "type": "SYMBOL",
-              "name": "statement_label"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "statement_label"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "("
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "statement_label"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "statement_label"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ")"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4109,8 +4109,41 @@
           "value": "*"
         },
         {
-          "type": "PATTERN",
-          "value": "\\d+"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "\\d+"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "STRING",
+                  "value": "*"
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8523,8 +8523,17 @@
                       "value": "="
                     },
                     {
-                      "type": "SYMBOL",
-                      "name": "number_literal"
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "number_literal"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "unary_expression"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -8558,8 +8567,17 @@
                             "value": "="
                           },
                           {
-                            "type": "SYMBOL",
-                            "name": "number_literal"
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SYMBOL",
+                                "name": "number_literal"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "unary_expression"
+                              }
+                            ]
                           }
                         ]
                       }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5264,7 +5264,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "identifier"
+                      "name": "_expression"
                     }
                   ]
                 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4872,6 +4872,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "arithmetic_if_statement"
+        },
+        {
+          "type": "SYMBOL",
           "name": "where_statement"
         },
         {
@@ -6199,7 +6203,7 @@
     },
     "_inline_if_statement": {
       "type": "PREC_RIGHT",
-      "value": 0,
+      "value": 2,
       "content": {
         "type": "SEQ",
         "members": [
@@ -6219,6 +6223,48 @@
           {
             "type": "SYMBOL",
             "name": "_statements"
+          }
+        ]
+      }
+    },
+    "arithmetic_if_statement": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "[iI][fF]"
+            },
+            "named": false,
+            "value": "if"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "parenthesized_expression"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "statement_label_reference"
+          },
+          {
+            "type": "STRING",
+            "value": ","
+          },
+          {
+            "type": "SYMBOL",
+            "name": "statement_label_reference"
+          },
+          {
+            "type": "STRING",
+            "value": ","
+          },
+          {
+            "type": "SYMBOL",
+            "name": "statement_label_reference"
           }
         ]
       }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5789,6 +5789,18 @@
           }
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "statement_label"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "end_do_loop_statement"
         }
@@ -6280,6 +6292,18 @@
             {
               "type": "SYMBOL",
               "name": "else_clause"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "statement_label"
             },
             {
               "type": "BLANK"
@@ -6823,6 +6847,18 @@
           }
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "statement_label"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "end_forall_statement"
         }
@@ -6930,6 +6966,18 @@
           }
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "statement_label"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "end_select_statement"
         }
@@ -6993,6 +7041,18 @@
           }
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "statement_label"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "end_select_statement"
         }
@@ -7054,6 +7114,18 @@
             "type": "SYMBOL",
             "name": "rank_statement"
           }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "statement_label"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4924,6 +4924,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "inquire_statement"
+        },
+        {
+          "type": "SYMBOL",
           "name": "stop_statement"
         },
         {
@@ -7888,290 +7892,9 @@
       "type": "PATTERN",
       "value": "[a-zA-Z0-9/:.*$]+"
     },
-    "read_statement": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_simple_read_statement"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_parameterized_read_statement"
-          }
-        ]
-      }
-    },
-    "_simple_read_statement": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "PATTERN",
-              "value": "[rR][eE][aA][dD]"
-            },
-            "named": false,
-            "value": "read"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "format_identifier"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "input_item_list"
-                  }
-                ]
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "_parameterized_read_statement": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "PATTERN",
-              "value": "[rR][eE][aA][dD]"
-            },
-            "named": false,
-            "value": "read"
-          },
-          {
-            "type": "STRING",
-            "value": "("
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "unit_identifier"
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "unit_identifier"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "format_identifier"
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "unit_identifier"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "format_identifier"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "keyword_argument"
-                      },
-                      {
-                        "type": "REPEAT",
-                        "content": {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ","
-                            },
-                            {
-                              "type": "SYMBOL",
-                              "name": "keyword_argument"
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "unit_identifier"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "keyword_argument"
-                      },
-                      {
-                        "type": "REPEAT",
-                        "content": {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ","
-                            },
-                            {
-                              "type": "SYMBOL",
-                              "name": "keyword_argument"
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "keyword_argument"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ","
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "keyword_argument"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "type": "STRING",
-            "value": ")"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "input_item_list"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "print_statement": {
+    "_io_arguments": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[pP][rR][iI][nN][tT]"
-          },
-          "named": false,
-          "value": "print"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "format_identifier"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ","
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "output_item_list"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
-    },
-    "open_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[oO][pP][eE][nN]"
-          },
-          "named": false,
-          "value": "open"
-        },
         {
           "type": "STRING",
           "value": "("
@@ -8314,6 +8037,157 @@
         {
           "type": "STRING",
           "value": ")"
+        }
+      ]
+    },
+    "read_statement": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_simple_read_statement"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_parameterized_read_statement"
+          }
+        ]
+      }
+    },
+    "_simple_read_statement": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "[rR][eE][aA][dD]"
+            },
+            "named": false,
+            "value": "read"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "format_identifier"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "input_item_list"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_parameterized_read_statement": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "[rR][eE][aA][dD]"
+            },
+            "named": false,
+            "value": "read"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_io_arguments"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "input_item_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "print_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[pP][rR][iI][nN][tT]"
+          },
+          "named": false,
+          "value": "print"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "format_identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "output_item_list"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "open_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[oO][pP][eE][nN]"
+          },
+          "named": false,
+          "value": "open"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_io_arguments"
         },
         {
           "type": "CHOICE",
@@ -8443,147 +8317,8 @@
             "value": "write"
           },
           {
-            "type": "STRING",
-            "value": "("
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "unit_identifier"
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "unit_identifier"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "format_identifier"
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "unit_identifier"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "format_identifier"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "keyword_argument"
-                      },
-                      {
-                        "type": "REPEAT",
-                        "content": {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ","
-                            },
-                            {
-                              "type": "SYMBOL",
-                              "name": "keyword_argument"
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "unit_identifier"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "keyword_argument"
-                      },
-                      {
-                        "type": "REPEAT",
-                        "content": {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ","
-                            },
-                            {
-                              "type": "SYMBOL",
-                              "name": "keyword_argument"
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "keyword_argument"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ","
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "keyword_argument"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "type": "STRING",
-            "value": ")"
+            "type": "SYMBOL",
+            "name": "_io_arguments"
           },
           {
             "type": "CHOICE",
@@ -8596,6 +8331,40 @@
                 "type": "BLANK"
               }
             ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "output_item_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "inquire_statement": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "[iI][nN][qQ][uU][iI][rR][eE]"
+            },
+            "named": false,
+            "value": "inquire"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_io_arguments"
           },
           {
             "type": "CHOICE",
@@ -10849,6 +10618,15 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
+            "value": "[iI][nN][qQ][uU][iI][rR][eE]"
+          },
+          "named": false,
+          "value": "inquire"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
             "value": "[rR][eE][aA][dD]"
           },
           "named": false,
@@ -11017,6 +10795,10 @@
     ],
     [
       "intrinsic_type",
+      "identifier"
+    ],
+    [
+      "inquire_statement",
       "identifier"
     ],
     [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -32,6 +32,19 @@
         "type": "CHOICE",
         "members": [
           {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "include_statement"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_end_of_statement"
+              }
+            ]
+          },
+          {
             "type": "SYMBOL",
             "name": "program"
           },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7871,6 +7871,10 @@
           "name": "edit_descriptor"
         },
         {
+          "type": "SYMBOL",
+          "name": "hollerith_constant"
+        },
+        {
           "type": "SEQ",
           "members": [
             {
@@ -7924,7 +7928,15 @@
     },
     "edit_descriptor": {
       "type": "PATTERN",
-      "value": "[a-zA-Z0-9/:.*$]+"
+      "value": "[a-gi-zA-GI-Z0-9/:.*$]+"
+    },
+    "hollerith_constant": {
+      "type": "PREC_RIGHT",
+      "value": 10,
+      "content": {
+        "type": "PATTERN",
+        "value": "[0-9]+H[^/,)]+"
+      }
     },
     "_io_arguments": {
       "type": "SEQ",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5285,7 +5285,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "statement_label"
+                  "name": "statement_label_reference"
                 },
                 {
                   "type": "SEQ",
@@ -5299,7 +5299,7 @@
                       "members": [
                         {
                           "type": "SYMBOL",
-                          "name": "statement_label"
+                          "name": "statement_label_reference"
                         },
                         {
                           "type": "REPEAT",
@@ -5312,7 +5312,7 @@
                               },
                               {
                                 "type": "SYMBOL",
-                                "name": "statement_label"
+                                "name": "statement_label_reference"
                               }
                             ]
                           }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1773,6 +1773,10 @@
           "named": true
         },
         {
+          "type": "complex_literal",
+          "named": true
+        },
+        {
           "type": "null_literal",
           "named": true
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -402,6 +402,10 @@
           "named": true
         },
         {
+          "type": "inquire_statement",
+          "named": true
+        },
+        {
           "type": "keyword_statement",
           "named": true
         },
@@ -683,6 +687,10 @@
           "named": true
         },
         {
+          "type": "inquire_statement",
+          "named": true
+        },
+        {
           "type": "interface",
           "named": true
         },
@@ -924,6 +932,10 @@
         },
         {
           "type": "include_statement",
+          "named": true
+        },
+        {
+          "type": "inquire_statement",
           "named": true
         },
         {
@@ -2117,6 +2129,10 @@
           "named": true
         },
         {
+          "type": "inquire_statement",
+          "named": true
+        },
+        {
           "type": "keyword_statement",
           "named": true
         },
@@ -2240,6 +2256,10 @@
           "named": true
         },
         {
+          "type": "inquire_statement",
+          "named": true
+        },
+        {
           "type": "keyword_statement",
           "named": true
         },
@@ -2352,6 +2372,10 @@
         },
         {
           "type": "include_statement",
+          "named": true
+        },
+        {
+          "type": "inquire_statement",
           "named": true
         },
         {
@@ -2471,6 +2495,10 @@
         },
         {
           "type": "include_statement",
+          "named": true
+        },
+        {
+          "type": "inquire_statement",
           "named": true
         },
         {
@@ -3028,6 +3056,10 @@
           "named": true
         },
         {
+          "type": "inquire_statement",
+          "named": true
+        },
+        {
           "type": "keyword_statement",
           "named": true
         },
@@ -3242,6 +3274,10 @@
         },
         {
           "type": "include_statement",
+          "named": true
+        },
+        {
+          "type": "inquire_statement",
           "named": true
         },
         {
@@ -3501,6 +3537,10 @@
         },
         {
           "type": "include_statement",
+          "named": true
+        },
+        {
+          "type": "inquire_statement",
           "named": true
         },
         {
@@ -3797,6 +3837,33 @@
         },
         {
           "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "inquire_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "format_identifier",
+          "named": true
+        },
+        {
+          "type": "keyword_argument",
+          "named": true
+        },
+        {
+          "type": "output_item_list",
+          "named": true
+        },
+        {
+          "type": "unit_identifier",
           "named": true
         }
       ]
@@ -4767,6 +4834,10 @@
           "named": true
         },
         {
+          "type": "inquire_statement",
+          "named": true
+        },
+        {
           "type": "interface",
           "named": true
         },
@@ -5523,6 +5594,10 @@
           "named": true
         },
         {
+          "type": "inquire_statement",
+          "named": true
+        },
+        {
           "type": "interface",
           "named": true
         },
@@ -5729,6 +5804,10 @@
         },
         {
           "type": "include_statement",
+          "named": true
+        },
+        {
+          "type": "inquire_statement",
           "named": true
         },
         {
@@ -6516,6 +6595,10 @@
           "named": true
         },
         {
+          "type": "inquire_statement",
+          "named": true
+        },
+        {
           "type": "interface",
           "named": true
         },
@@ -7002,6 +7085,10 @@
           "named": true
         },
         {
+          "type": "inquire_statement",
+          "named": true
+        },
+        {
           "type": "keyword_statement",
           "named": true
         },
@@ -7421,6 +7508,10 @@
         },
         {
           "type": "include_statement",
+          "named": true
+        },
+        {
+          "type": "inquire_statement",
           "named": true
         },
         {
@@ -8026,6 +8117,10 @@
   },
   {
     "type": "inout",
+    "named": false
+  },
+  {
+    "type": "inquire",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3982,7 +3982,7 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4051,7 +4051,7 @@
           "named": true
         },
         {
-          "type": "statement_label",
+          "type": "statement_label_reference",
           "named": true
         },
         {
@@ -8078,11 +8078,11 @@
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1777,6 +1777,10 @@
           "named": true
         },
         {
+          "type": "identifier",
+          "named": true
+        },
+        {
           "type": "null_literal",
           "named": true
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3582,6 +3582,11 @@
     }
   },
   {
+    "type": "hollerith_constant",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "identifier",
     "named": true,
     "fields": {}
@@ -7081,6 +7086,10 @@
       "types": [
         {
           "type": "edit_descriptor",
+          "named": true
+        },
+        {
+          "type": "hollerith_constant",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3702,7 +3702,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "assignment",
@@ -8058,11 +8058,11 @@
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -97,6 +97,25 @@
     }
   },
   {
+    "type": "arithmetic_if_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "statement_label_reference",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "array_literal",
     "named": true,
     "fields": {
@@ -341,6 +360,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
         {
           "type": "assignment_statement",
           "named": true
@@ -602,6 +625,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
         {
           "type": "assignment_statement",
           "named": true
@@ -874,6 +901,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
         {
           "type": "assignment_statement",
           "named": true
@@ -2069,6 +2100,10 @@
       "required": true,
       "types": [
         {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
+        {
           "type": "assignment_statement",
           "named": true
         },
@@ -2204,6 +2239,10 @@
       "required": false,
       "types": [
         {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
+        {
           "type": "assignment_statement",
           "named": true
         },
@@ -2322,6 +2361,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
         {
           "type": "assignment_statement",
           "named": true
@@ -2445,6 +2488,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
         {
           "type": "assignment_statement",
           "named": true
@@ -3000,6 +3047,10 @@
       "required": true,
       "types": [
         {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
+        {
           "type": "assignment_statement",
           "named": true
         },
@@ -3192,6 +3243,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
         {
           "type": "assignment_statement",
           "named": true
@@ -3471,6 +3526,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
         {
           "type": "assignment_statement",
           "named": true
@@ -4754,6 +4813,10 @@
       "required": true,
       "types": [
         {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
+        {
           "type": "assignment_statement",
           "named": true
         },
@@ -5514,6 +5577,10 @@
       "required": true,
       "types": [
         {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
+        {
           "type": "assignment_statement",
           "named": true
         },
@@ -5746,6 +5813,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
         {
           "type": "assignment_statement",
           "named": true
@@ -6515,6 +6586,10 @@
       "required": true,
       "types": [
         {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
+        {
           "type": "assignment_statement",
           "named": true
         },
@@ -7029,6 +7104,10 @@
       "required": false,
       "types": [
         {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
+        {
           "type": "assignment_statement",
           "named": true
         },
@@ -7450,6 +7529,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "arithmetic_if_statement",
+          "named": true
+        },
         {
           "type": "assignment_statement",
           "named": true
@@ -8173,11 +8256,11 @@
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -8058,11 +8058,11 @@
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -6043,6 +6043,10 @@
         {
           "type": "selector",
           "named": true
+        },
+        {
+          "type": "statement_label",
+          "named": true
         }
       ]
     }
@@ -6070,6 +6074,10 @@
         {
           "type": "selector",
           "named": true
+        },
+        {
+          "type": "statement_label",
+          "named": true
         }
       ]
     }
@@ -6092,6 +6100,10 @@
         },
         {
           "type": "selector",
+          "named": true
+        },
+        {
+          "type": "statement_label",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -74,6 +74,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "number_literal",
           "named": true
         },
@@ -187,6 +191,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "number_literal",
           "named": true
         },
@@ -263,6 +271,10 @@
             "named": true
           },
           {
+            "type": "null_literal",
+            "named": true
+          },
+          {
             "type": "number_literal",
             "named": true
           },
@@ -326,6 +338,10 @@
           },
           {
             "type": "math_expression",
+            "named": true
+          },
+          {
+            "type": "null_literal",
             "named": true
           },
           {
@@ -539,6 +555,10 @@
           },
           {
             "type": "math_expression",
+            "named": true
+          },
+          {
+            "type": "null_literal",
             "named": true
           },
           {
@@ -871,6 +891,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "number_literal",
           "named": true
         },
@@ -1077,6 +1101,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "number_literal",
           "named": true
         },
@@ -1214,6 +1242,10 @@
             "named": true
           },
           {
+            "type": "null_literal",
+            "named": true
+          },
+          {
             "type": "number_literal",
             "named": true
           },
@@ -1290,6 +1322,10 @@
             "named": true
           },
           {
+            "type": "null_literal",
+            "named": true
+          },
+          {
             "type": "number_literal",
             "named": true
           },
@@ -1362,6 +1398,10 @@
             "named": true
           },
           {
+            "type": "null_literal",
+            "named": true
+          },
+          {
             "type": "number_literal",
             "named": true
           },
@@ -1428,6 +1468,10 @@
             "named": true
           },
           {
+            "type": "null_literal",
+            "named": true
+          },
+          {
             "type": "number_literal",
             "named": true
           },
@@ -1491,6 +1535,10 @@
           },
           {
             "type": "math_expression",
+            "named": true
+          },
+          {
+            "type": "null_literal",
             "named": true
           },
           {
@@ -1625,6 +1673,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "number_literal",
           "named": true
         },
@@ -1717,6 +1769,10 @@
         },
         {
           "type": "math_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -1968,6 +2024,10 @@
         },
         {
           "type": "math_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -2997,6 +3057,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "number_literal",
           "named": true
         },
@@ -3750,6 +3814,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "number_literal",
           "named": true
         },
@@ -3880,6 +3948,10 @@
         },
         {
           "type": "math_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -4097,6 +4169,10 @@
             "named": true
           },
           {
+            "type": "null_literal",
+            "named": true
+          },
+          {
             "type": "number_literal",
             "named": true
           },
@@ -4166,6 +4242,10 @@
         },
         {
           "type": "math_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -4273,6 +4353,10 @@
             "named": true
           },
           {
+            "type": "null_literal",
+            "named": true
+          },
+          {
             "type": "number_literal",
             "named": true
           },
@@ -4361,6 +4445,10 @@
             "named": true
           },
           {
+            "type": "null_literal",
+            "named": true
+          },
+          {
             "type": "number_literal",
             "named": true
           },
@@ -4425,6 +4513,10 @@
         },
         {
           "type": "math_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -4499,6 +4591,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "number_literal",
           "named": true
         },
@@ -4567,6 +4663,10 @@
           },
           {
             "type": "math_expression",
+            "named": true
+          },
+          {
+            "type": "null_literal",
             "named": true
           },
           {
@@ -4663,6 +4763,10 @@
           },
           {
             "type": "math_expression",
+            "named": true
+          },
+          {
+            "type": "null_literal",
             "named": true
           },
           {
@@ -5081,6 +5185,11 @@
     }
   },
   {
+    "type": "null_literal",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "number_literal",
     "named": true,
     "fields": {}
@@ -5166,6 +5275,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "number_literal",
           "named": true
         },
@@ -5234,6 +5347,10 @@
         },
         {
           "type": "math_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -5338,6 +5455,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "number_literal",
           "named": true
         },
@@ -5406,6 +5527,10 @@
         },
         {
           "type": "math_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -6016,6 +6141,10 @@
             "named": true
           },
           {
+            "type": "null_literal",
+            "named": true
+          },
+          {
             "type": "number_literal",
             "named": true
           },
@@ -6133,6 +6262,10 @@
           },
           {
             "type": "math_expression",
+            "named": true
+          },
+          {
+            "type": "null_literal",
             "named": true
           },
           {
@@ -6316,6 +6449,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "number_literal",
           "named": true
         },
@@ -6421,6 +6558,10 @@
         },
         {
           "type": "math_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -6825,6 +6966,10 @@
             "named": true
           },
           {
+            "type": "null_literal",
+            "named": true
+          },
+          {
             "type": "number_literal",
             "named": true
           },
@@ -7030,6 +7175,10 @@
         },
         {
           "type": "math_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -7272,6 +7421,10 @@
           },
           {
             "type": "math_expression",
+            "named": true
+          },
+          {
+            "type": "null_literal",
             "named": true
           },
           {
@@ -8271,8 +8424,8 @@
     "named": false
   },
   {
-    "type": "null_literal",
-    "named": true
+    "type": "null",
+    "named": false
   },
   {
     "type": "only",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1057,6 +1057,11 @@
     }
   },
   {
+    "type": "character_length",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "close_statement",
     "named": true,
     "fields": {},
@@ -7178,6 +7183,10 @@
           "named": true
         },
         {
+          "type": "character_length",
+          "named": true
+        },
+        {
           "type": "derived_type",
           "named": true
         },
@@ -7241,6 +7250,10 @@
         },
         {
           "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "character_length",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3995,11 +3995,67 @@
       "required": false,
       "types": [
         {
+          "type": "array_literal",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "complex_literal",
+          "named": true
+        },
+        {
+          "type": "concatenation_expression",
+          "named": true
+        },
+        {
+          "type": "derived_type_member_expression",
+          "named": true
+        },
+        {
           "type": "identifier",
           "named": true
         },
         {
+          "type": "implied_do_loop_expression",
+          "named": true
+        },
+        {
+          "type": "logical_expression",
+          "named": true
+        },
+        {
+          "type": "math_expression",
+          "named": true
+        },
+        {
+          "type": "number_literal",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "relational_expression",
+          "named": true
+        },
+        {
           "type": "statement_label",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
           "named": true
         }
       ]
@@ -8002,11 +8058,11 @@
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -6784,6 +6784,10 @@
           "named": true
         },
         {
+          "type": "include_statement",
+          "named": true
+        },
+        {
           "type": "interface",
           "named": true
         },
@@ -8062,11 +8066,11 @@
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -8062,11 +8062,11 @@
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -8256,11 +8256,11 @@
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2902,6 +2902,10 @@
         {
           "type": "number_literal",
           "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
         }
       ]
     }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -71,8 +71,7 @@ bool scan_number(TSLexer *lexer) {
         // exclude decimal if followed by any letter other than d/D and e/E
         // if no leading digits are present and a non-digit follows
         // the decimal it's a nonmatch.
-        if (digits && (is_exp_sentinel(lexer->lookahead) ||
-                       !iswalnum(lexer->lookahead))) {
+        if (digits && !iswalnum(lexer->lookahead)) {
             lexer->mark_end(lexer); // add decimal to token
         }
         lexer->result_symbol = FLOAT_LITERAL;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -263,7 +263,7 @@ bool scan_string_literal(TSLexer *lexer) {
             }
             // If we hit the end of the line, consume all whitespace,
             // including new lines
-            if (lexer->lookahead == '\n') {
+            if (lexer->lookahead == '\n' || lexer->lookahead == '\r') {
                 while (iswspace(lexer->lookahead)) {
                     advance(lexer);
                 }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -58,6 +58,21 @@ bool scan_int(TSLexer *lexer) {
         advance(lexer); // store all digits
     }
 
+    // handle line continuations
+    if (lexer->lookahead == '&') {
+      skip(lexer);
+      while (iswspace(lexer->lookahead)) {
+        skip(lexer);
+      }
+      // second '&' required to continue the literal
+      if (lexer->lookahead == '&') {
+        skip(lexer);
+        // don't return here, as we may have finished literal on first
+        // line but still have second '&'
+        scan_int(lexer);
+      }
+    }
+
     lexer->mark_end(lexer);
     return true;
 }

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -546,6 +546,7 @@ program test
        generic, pass :: binding_name => method_name, method_name2
        generic, private :: assignment(=) => assign_method
        generic, private :: operator(+) => add_method
+       procedure :: one, two => three
        final :: finalize
   end type custom_type
 end program
@@ -591,6 +592,7 @@ end program
           (procedure_statement (procedure_attribute) (binding_name (identifier)) (method_name) (method_name))
           (procedure_statement (procedure_attribute) (binding_name (assignment)) (method_name))
           (procedure_statement (procedure_attribute) (binding_name (operator)) (method_name))          
+          (procedure_statement (method_name) (binding_name (identifier)) (method_name))
           (procedure_statement (method_name)))
       (end_type_statement (name)))
   (end_program_statement)))

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -538,6 +538,7 @@ program test
     real(8) :: x,y,z
     integer :: w,h,l
     real(eb), allocatable, dimension(:, :, :) :: vals
+    procedure(), pointer, nopass :: do_nothing => null()
     contains
        procedure, nopass, non_overridable :: static_method ! static method
        procedure instance_method ! instance method
@@ -576,6 +577,10 @@ end program
         (type_qualifier
           (argument_list (extent_specifier) (extent_specifier) (extent_specifier)))
         (identifier))
+      (variable_declaration
+        (procedure
+          (procedure_attribute) (procedure_attribute))
+        (pointer_association_statement (identifier) (null_literal)))
       (derived_type_procedures
           (contains_statement)
           (procedure_statement (procedure_attribute) (procedure_attribute) (method_name))
@@ -585,7 +590,7 @@ end program
           (procedure_statement (procedure_attribute) (procedure_attribute (identifier)) (method_name))
           (procedure_statement (procedure_attribute) (binding_name (identifier)) (method_name) (method_name))
           (procedure_statement (procedure_attribute) (binding_name (assignment)) (method_name))
-          (procedure_statement (procedure_attribute) (binding_name (operator)) (method_name))
+          (procedure_statement (procedure_attribute) (binding_name (operator)) (method_name))          
           (procedure_statement (method_name)))
       (end_type_statement (name)))
   (end_program_statement)))
@@ -702,7 +707,7 @@ end program test
       (derived_type_statement (type_name))
       (variable_declaration
         (procedure (procedure_interface) (procedure_attribute))
-        (pointer_association_statement (identifier) (call_expression (identifier) (argument_list))))
+        (pointer_association_statement (identifier) (null_literal)))
       (variable_declaration
         (procedure (procedure_interface) (procedure_attribute) (procedure_attribute))
         (identifier))

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -19,6 +19,18 @@ END PROGRAM TEST
     (end_program_statement (name))))
 
 ============================================
+Shortest Program
+============================================
+
+END
+
+---
+
+(translation_unit
+  (program
+    (end_program_statement)))
+
+============================================
 Interface (explicit)
 ============================================
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -351,6 +351,7 @@ PROGRAM TEST
     val = .NOT. x
     val = (.NOT. x == y)
     val = ((x > y) .AND. (y <= z)) .eqv. .true.
+    val = 1.eq.0
 END PROGRAM
 
 ----
@@ -405,6 +406,8 @@ END PROGRAM
             (parenthesized_expression
               (relational_expression (identifier) (identifier)))))
         (boolean_literal)))
+    (assignment_statement (identifier)
+      (relational_expression (number_literal) (number_literal)))
   (end_program_statement)))
 
 ============================================

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -560,6 +560,44 @@ end program test
     (end_program_statement (name))))
 
 ============================================
+Line Continuation in Number Literals
+============================================
+
+program test
+  real, parameter :: pi = &
+    &3.14&
+    &1592&
+    &6535&
+    &8979
+  integer, dimension(2) :: foo = [1&
+    , 2]
+  real, dimension(2) :: foo = [1.e0&
+    &, 2.e0]
+end program
+
+---
+
+(translation_unit
+  (program
+    (program_statement (name))
+    (variable_declaration (intrinsic_type)
+      (type_qualifier)
+      (assignment_statement
+        (identifier)
+        (number_literal)))
+    (variable_declaration (intrinsic_type)
+      (type_qualifier (argument_list (number_literal)))
+      (assignment_statement
+        (identifier)
+        (array_literal (number_literal) (number_literal))))
+    (variable_declaration (intrinsic_type)
+      (type_qualifier (argument_list (number_literal)))
+      (assignment_statement
+        (identifier)
+        (array_literal (number_literal) (number_literal))))
+    (end_program_statement)))
+
+============================================
 Array Constructors
 ============================================
 

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1209,6 +1209,9 @@ PROGRAM test
         ENUMERATOR :: red = 1
         ENUMERATOR blue, green
     END ENUM
+    ENUM, BIND(C)
+        ENUMERATOR :: minus_one = -1
+    END ENUM
 END PROGRAM test
 
 ----
@@ -1220,6 +1223,10 @@ END PROGRAM test
       (enum_statement (language_binding (identifier)))
       (enumerator_statement (identifier) (number_literal))
       (enumerator_statement (identifier) (identifier))
+      (end_enum_statement))
+    (enum
+      (enum_statement (language_binding (identifier)))
+      (enumerator_statement (identifier) (unary_expression (number_literal)))
       (end_enum_statement))
     (end_program_statement (name))))
 

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -31,6 +31,8 @@ PROGRAM TEST
   use my_module, only: func2 => foo
   use, intrinsic:: iso_fortran_env, stderr => error_unit
   use :: some_mod
+  use some_mod, only:
+  use some_mod, func2 => foo
 END PROGRAM
 
 ----
@@ -50,6 +52,10 @@ END PROGRAM
     (use_statement (module_name)
       (use_alias (local_name) (identifier)))
     (use_statement (module_name))
+    (use_statement (module_name)
+      (included_items))
+    (use_statement (module_name)
+      (use_alias (local_name) (identifier)))
   (end_program_statement)))
 
 ============================================

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1702,3 +1702,19 @@ end program test
       (keyword_argument (identifier) (identifier))
       (keyword_argument (identifier) (identifier)))
     (end_program_statement (name))))
+
+========================================
+Arithmetic If Statement (Deleted)
+========================================
+
+  if (d) 10, 20, 30
+end
+
+---
+
+(translation_unit
+  (program
+    (arithmetic_if_statement
+      (parenthesized_expression (identifier))
+      (statement_label_reference) (statement_label_reference) (statement_label_reference))
+    (end_program_statement)))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -305,6 +305,7 @@ PROGRAM TEST
   TARGET :: i
   PARAMETER (MAXLEN = 255, PI = 3.1415, SCALE_FACTOR = SIN(2 * PI))
   EQUIVALENCE (a, b, c), (d, e, f, r(1))
+  SAVE A, B, /BLOCKC/, D
 END PROGRAM
 
 ----
@@ -330,6 +331,7 @@ END PROGRAM
         (identifier)
         (identifier)
         (call_expression (identifier) (argument_list (number_literal)))))
+    (save_statement (identifier) (identifier) (identifier) (identifier))
   (end_program_statement)))
 
 ============================================

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1536,6 +1536,7 @@ program test
   DATA (array(1,k),k=1,n) /3.14e-3, -42.5/
   DATA array(:, N) / &
     54.45_fp, 200.01_fp /
+  DATA complex_array / ( 0, 1 ), ( 1, 0 ) /
 
   ! This is awful, but this makes sure the specification part has
   ! finished, as is a hacky workaround to make sure the next part is
@@ -1591,6 +1592,11 @@ end program test
         (call_expression (identifier) (argument_list (extent_specifier) (identifier)))
         (data_value
           (number_literal) (number_literal))))
+    (data_statement
+      (data_set
+        (identifier)
+        (data_value (complex_literal (number_literal) (number_literal))
+                    (complex_literal (number_literal) (number_literal)))))
     (comment)
     (comment)
     (comment)

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -507,6 +507,7 @@ Computed Goto (Obsolescent)
 
 program test
   goto (10, 20, 30) M
+  goto (10, 20, 30) ISAVE(1)
 end program
 
 ---
@@ -515,6 +516,8 @@ end program
   (program
     (program_statement (name))
     (keyword_statement (statement_label) (statement_label) (statement_label) (identifier))
+    (keyword_statement (statement_label) (statement_label) (statement_label)
+                       (call_expression (identifier) (argument_list (number_literal))))
     (end_program_statement)))
 
 ============================================

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -141,7 +141,7 @@ PROGRAM TEST
   CHARACTER(LEN=*) :: options
   CHARACTER*(MXLN) :: errflag
   CHARACTER(*) :: thing
-  CHARACTER   FMAT*22
+  CHARACTER   FMAT*22, OTHER*(*)
   integer::no_whitespace=1
 END PROGRAM
 
@@ -191,6 +191,7 @@ END PROGRAM
       (identifier))
     (variable_declaration
       (intrinsic_type)
+      (identifier) (character_length)
       (identifier) (character_length))
     (variable_declaration
       (intrinsic_type)

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -966,6 +966,7 @@ PROGRAM TEST
 3 FORMAT(I0, A(2X, I3), 'test')
 4 FORMAT(*(G15.8,:,','))
 5 FORMAT(/1X,'NUMBER OF DATA Total/ACCEPTED'/1X,i10/1X)
+6 FORMAT(3(1H-), 2HOK, 10H SOLUTION // 5D15.7)
 END PROGRAM
 
 ----
@@ -1003,6 +1004,15 @@ END PROGRAM
       (transfer_items
         (edit_descriptor)
         (string_literal)
+        (edit_descriptor)
+        (edit_descriptor)))
+    (statement_label)
+    (format_statement
+      (transfer_items
+        (edit_descriptor)
+        (hollerith_constant)
+        (hollerith_constant)
+        (hollerith_constant)
         (edit_descriptor)
         (edit_descriptor)))
   (end_program_statement)))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -141,6 +141,7 @@ PROGRAM TEST
   CHARACTER(LEN=*) :: options
   CHARACTER*(MXLN) :: errflag
   CHARACTER(*) :: thing
+  CHARACTER   FMAT*22
   integer::no_whitespace=1
 END PROGRAM
 
@@ -188,6 +189,9 @@ END PROGRAM
     (variable_declaration
       (intrinsic_type) (size (argument_list (assumed_size)))
       (identifier))
+    (variable_declaration
+      (intrinsic_type)
+      (identifier) (character_length))
     (variable_declaration
       (intrinsic_type)
       (assignment_statement (identifier) (number_literal)))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1674,3 +1674,31 @@ end program
       (parenthesized_expression (call_expression (identifier) (argument_list (identifier))))))
     (file_position_statement (string_literal))
     (end_program_statement)))
+
+========================================
+Inquire Statements
+========================================
+
+program test
+  INQUIRE (IOLENGTH = IOL) A (1:N)
+  INQUIRE (UNIT = JOAN, OPENED = LOG_01, NAMED = LOG_02, &
+           FORM = CHAR_VAR, IOSTAT = IOS)
+end program test
+
+---
+
+(translation_unit
+  (program
+    (program_statement (name))
+    (inquire_statement
+      (keyword_argument (identifier) (identifier))
+      (output_item_list
+        (call_expression (identifier)
+          (argument_list (extent_specifier (number_literal) (identifier))))))
+    (inquire_statement
+      (keyword_argument (identifier) (identifier))
+      (keyword_argument (identifier) (identifier))
+      (keyword_argument (identifier) (identifier))
+      (keyword_argument (identifier) (identifier))
+      (keyword_argument (identifier) (identifier)))
+    (end_program_statement (name))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -365,6 +365,11 @@ PROGRAM TEST
     DO WHILE (is_true)
         j = 0
     END DO
+
+    do i = 1, 10
+      if (diff) go to 100
+100 end do
+
 END PROGRAM
 
 ----
@@ -420,6 +425,14 @@ END PROGRAM
           (identifier )))
       (assignment_statement
         (identifier) (number_literal))
+      (end_do_loop_statement))
+    (do_loop_statement
+      (loop_control_expression
+        (identifier) (number_literal) (number_literal))
+      (if_statement
+        (parenthesized_expression (identifier))
+        (keyword_statement (statement_label)))
+      (statement_label)
       (end_do_loop_statement))
   (end_program_statement)))
 

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -497,6 +497,22 @@ end program test
     (end_program_statement (name))))
 
 ============================================
+Computed Goto (Obsolescent)
+============================================
+
+program test
+  goto (10, 20, 30) M
+end program
+
+---
+
+(translation_unit
+  (program
+    (program_statement (name))
+    (keyword_statement (statement_label) (statement_label) (statement_label) (identifier))
+    (end_program_statement)))
+
+============================================
 If Statements
 ============================================
 

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1549,6 +1549,7 @@ program test
   DATA array(:, N) / &
     54.45_fp, 200.01_fp /
   DATA complex_array / ( 0, 1 ), ( 1, 0 ) /
+  data params/ param1, param2/
 
   ! This is awful, but this makes sure the specification part has
   ! finished, as is a hacky workaround to make sure the next part is
@@ -1609,6 +1610,9 @@ end program test
         (identifier)
         (data_value (complex_literal (number_literal) (number_literal))
                     (complex_literal (number_literal) (number_literal)))))
+    (data_statement
+      (data_set (identifier)
+        (data_value (identifier) (identifier))))
     (comment)
     (comment)
     (comment)

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -397,7 +397,7 @@ END PROGRAM
         (call_expression (identifier) (argument_list (identifier)))
         (identifier))
       (keyword_statement)
-      (keyword_statement (statement_label))
+      (keyword_statement (statement_label_reference))
     (end_do_loop_statement))
     (do_loop_statement
       (block_label_start_expression)
@@ -431,7 +431,7 @@ END PROGRAM
         (identifier) (number_literal) (number_literal))
       (if_statement
         (parenthesized_expression (identifier))
-        (keyword_statement (statement_label)))
+        (keyword_statement (statement_label_reference)))
       (statement_label)
       (end_do_loop_statement))
   (end_program_statement)))
@@ -536,9 +536,12 @@ end program
 (translation_unit
   (program
     (program_statement (name))
-    (keyword_statement (statement_label) (statement_label) (statement_label) (identifier))
-    (keyword_statement (statement_label) (statement_label) (statement_label)
-                       (call_expression (identifier) (argument_list (number_literal))))
+    (keyword_statement
+      (statement_label_reference) (statement_label_reference) (statement_label_reference)
+      (identifier))
+    (keyword_statement
+      (statement_label_reference) (statement_label_reference) (statement_label_reference)
+      (call_expression (identifier) (argument_list (number_literal))))
     (end_program_statement)))
 
 ============================================


### PR DESCRIPTION
A few more Fortran77, obsolescent, and deleted features, and some bug fixes:

- Computed gotos
- Complex literals in `data` statements
- `character*n` and `character*(*)` declarations
- Fix for `1.eq.0` expressions
- Make initial `program` keyword optional
  - This required fiddling about with various precedences, but has allowed for parsing more snippets