### PR TITLE
Fix usage of hidden external node

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -74,7 +74,6 @@ module.exports = grammar({
 
   conflicts: $ => [
     [$._expression, $.complex_literal],
-    [$._inline_if_statement, $._block_if_statement, $.identifier],
     [$.argument_list, $.parenthesized_expression],
     [$.case_statement],
     [$.data_set, $._expression],
@@ -83,18 +82,14 @@ module.exports = grammar({
     [$.elseif_clause, $.identifier],
     [$.elseif_clause],
     [$.elsewhere_clause],
-    [$.format_statement, $.identifier],
     [$.interface_statement],
     [$.intrinsic_type, $.identifier],
-    [$.inquire_statement, $.identifier],
     [$.module_statement, $.procedure_qualifier],
-    [$.null_literal, $.identifier],
     [$.procedure_declaration],
     [$.rank_statement],
     [$.stop_statement, $.identifier],
     [$.type_qualifier, $.identifier],
     [$.type_statement],
-    [$.translation_unit],
   ],
 
   rules: {

--- a/grammar.js
+++ b/grammar.js
@@ -52,7 +52,7 @@ module.exports = grammar({
   name: 'fortran',
 
   externals: $ => [
-    $._line_continuation,
+    '&',
     $._integer_literal,
     $._float_literal,
     $._boz_literal,
@@ -63,7 +63,7 @@ module.exports = grammar({
   extras: $ => [
     /[ \t\r\n]/,
     $.comment,
-    $._line_continuation,
+    '&',
     $.preproc_file_line
   ],
 
@@ -1609,8 +1609,6 @@ module.exports = grammar({
     ),
 
     comment: $ => token(seq('!', /.*/)),
-
-    _line_continuation: $ => '&',
 
     _semicolon: $ => ';',
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -125,7 +125,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[pP][rR][oO][gG][rR][aA][mM]"
+            "value": "program",
+            "flags": "i"
           },
           "named": false,
           "value": "program"
@@ -152,14 +153,16 @@
                   "members": [
                     {
                       "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
+                      "value": "end",
+                      "flags": "i"
                     },
                     {
                       "type": "CHOICE",
                       "members": [
                         {
                           "type": "PATTERN",
-                          "value": "[pP][rR][oO][gG][rR][aA][mM]"
+                          "value": "program",
+                          "flags": "i"
                         },
                         {
                           "type": "BLANK"
@@ -170,7 +173,8 @@
                 },
                 {
                   "type": "PATTERN",
-                  "value": "[eE][nN][dD][pP][rR][oO][gG][rR][aA][mM]"
+                  "value": "endprogram",
+                  "flags": "i"
                 }
               ]
             },
@@ -235,7 +239,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[mM][oO][dD][uU][lL][eE]"
+            "value": "module",
+            "flags": "i"
           },
           "named": false,
           "value": "module"
@@ -262,14 +267,16 @@
                   "members": [
                     {
                       "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
+                      "value": "end",
+                      "flags": "i"
                     },
                     {
                       "type": "CHOICE",
                       "members": [
                         {
                           "type": "PATTERN",
-                          "value": "[mM][oO][dD][uU][lL][eE]"
+                          "value": "module",
+                          "flags": "i"
                         },
                         {
                           "type": "BLANK"
@@ -280,7 +287,8 @@
                 },
                 {
                   "type": "PATTERN",
-                  "value": "[eE][nN][dD][mM][oO][dD][uU][lL][eE]"
+                  "value": "endmodule",
+                  "flags": "i"
                 }
               ]
             },
@@ -345,7 +353,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[sS][uU][bB][mM][oO][dD][uU][lL][eE]"
+            "value": "submodule",
+            "flags": "i"
           },
           "named": false,
           "value": "submodule"
@@ -413,14 +422,16 @@
                   "members": [
                     {
                       "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
+                      "value": "end",
+                      "flags": "i"
                     },
                     {
                       "type": "CHOICE",
                       "members": [
                         {
                           "type": "PATTERN",
-                          "value": "[sS][uU][bB][mM][oO][dD][uU][lL][eE]"
+                          "value": "submodule",
+                          "flags": "i"
                         },
                         {
                           "type": "BLANK"
@@ -431,7 +442,8 @@
                 },
                 {
                   "type": "PATTERN",
-                  "value": "[eE][nN][dD][sS][uU][bB][mM][oO][dD][uU][lL][eE]"
+                  "value": "endsubmodule",
+                  "flags": "i"
                 }
               ]
             },
@@ -517,7 +529,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[iI][nN][tT][eE][rR][fF][aA][cC][eE]"
+            "value": "interface",
+            "flags": "i"
           },
           "named": false,
           "value": "interface"
@@ -561,17 +574,20 @@
                   "members": [
                     {
                       "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
+                      "value": "end",
+                      "flags": "i"
                     },
                     {
                       "type": "PATTERN",
-                      "value": "[iI][nN][tT][eE][rR][fF][aA][cC][eE]"
+                      "value": "interface",
+                      "flags": "i"
                     }
                   ]
                 },
                 {
                   "type": "PATTERN",
-                  "value": "[eE][nN][dD][iI][nN][tT][eE][rR][fF][aA][cC][eE]"
+                  "value": "endinterface",
+                  "flags": "i"
                 }
               ]
             },
@@ -613,7 +629,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[aA][sS][sS][iI][gG][nN][mM][eE][nN][tT]"
+            "value": "assignment",
+            "flags": "i"
           },
           "named": false,
           "value": "assignment"
@@ -639,7 +656,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[oO][pP][eE][rR][aA][tT][oO][rR]"
+            "value": "operator",
+            "flags": "i"
           },
           "named": false,
           "value": "operator"
@@ -668,7 +686,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[rR][eE][aA][dD]"
+                "value": "read",
+                "flags": "i"
               },
               "named": false,
               "value": "read"
@@ -677,7 +696,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[wW][rR][iI][tT][eE]"
+                "value": "write",
+                "flags": "i"
               },
               "named": false,
               "value": "write"
@@ -695,7 +715,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[fF][oO][rR][mM][aA][tT][tT][eE][dD]"
+                "value": "formatted",
+                "flags": "i"
               },
               "named": false,
               "value": "formatted"
@@ -704,7 +725,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[uU][nN][fF][oO][rR][mM][aA][tT][tT][eE][dD]"
+                "value": "unformatted",
+                "flags": "i"
               },
               "named": false,
               "value": "unformatted"
@@ -796,7 +818,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[sS][uU][bB][rR][oO][uU][tT][iI][nN][eE]"
+            "value": "subroutine",
+            "flags": "i"
           },
           "named": false,
           "value": "subroutine"
@@ -855,14 +878,16 @@
                   "members": [
                     {
                       "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
+                      "value": "end",
+                      "flags": "i"
                     },
                     {
                       "type": "CHOICE",
                       "members": [
                         {
                           "type": "PATTERN",
-                          "value": "[sS][uU][bB][rR][oO][uU][tT][iI][nN][eE]"
+                          "value": "subroutine",
+                          "flags": "i"
                         },
                         {
                           "type": "BLANK"
@@ -873,7 +898,8 @@
                 },
                 {
                   "type": "PATTERN",
-                  "value": "[eE][nN][dD][sS][uU][bB][rR][oO][uU][tT][iI][nN][eE]"
+                  "value": "endsubroutine",
+                  "flags": "i"
                 }
               ]
             },
@@ -964,7 +990,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[mM][oO][dD][uU][lL][eE]"
+                "value": "module",
+                "flags": "i"
               },
               "named": false,
               "value": "module"
@@ -973,7 +1000,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[pP][rR][oO][cC][eE][dD][uU][rR][eE]"
+                "value": "procedure",
+                "flags": "i"
               },
               "named": false,
               "value": "procedure"
@@ -1006,14 +1034,16 @@
                   "members": [
                     {
                       "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
+                      "value": "end",
+                      "flags": "i"
                     },
                     {
                       "type": "CHOICE",
                       "members": [
                         {
                           "type": "PATTERN",
-                          "value": "[pP][rR][oO][cC][eE][dD][uU][rR][eE]"
+                          "value": "procedure",
+                          "flags": "i"
                         },
                         {
                           "type": "BLANK"
@@ -1024,7 +1054,8 @@
                 },
                 {
                   "type": "PATTERN",
-                  "value": "[eE][nN][dD][pP][rR][oO][cC][eE][dD][uU][rR][eE]"
+                  "value": "endprocedure",
+                  "flags": "i"
                 }
               ]
             },
@@ -1112,7 +1143,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[fF][uU][nN][cC][tT][iI][oO][nN]"
+            "value": "function",
+            "flags": "i"
           },
           "named": false,
           "value": "function"
@@ -1174,7 +1206,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[bB][iI][nN][dD]"
+            "value": "bind",
+            "flags": "i"
           },
           "named": false,
           "value": "bind"
@@ -1252,7 +1285,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[aA][tT][tT][rR][iI][bB][uU][tT][eE][sS]"
+              "value": "attributes",
+              "flags": "i"
             },
             "named": false,
             "value": "attributes"
@@ -1271,7 +1305,8 @@
                     "type": "ALIAS",
                     "content": {
                       "type": "PATTERN",
-                      "value": "[gG][lL][oO][bB][aA][lL]"
+                      "value": "global",
+                      "flags": "i"
                     },
                     "named": false,
                     "value": "global"
@@ -1280,7 +1315,8 @@
                     "type": "ALIAS",
                     "content": {
                       "type": "PATTERN",
-                      "value": "[dD][eE][vV][iI][cC][eE]"
+                      "value": "device",
+                      "flags": "i"
                     },
                     "named": false,
                     "value": "device"
@@ -1289,7 +1325,8 @@
                     "type": "ALIAS",
                     "content": {
                       "type": "PATTERN",
-                      "value": "[hH][oO][sS][tT]"
+                      "value": "host",
+                      "flags": "i"
                     },
                     "named": false,
                     "value": "host"
@@ -1298,7 +1335,8 @@
                     "type": "ALIAS",
                     "content": {
                       "type": "PATTERN",
-                      "value": "[gG][rR][iI][dD]_[gG][lL][oO][bB][aA][lL]"
+                      "value": "grid_global",
+                      "flags": "i"
                     },
                     "named": false,
                     "value": "grid_global"
@@ -1321,7 +1359,8 @@
                           "type": "ALIAS",
                           "content": {
                             "type": "PATTERN",
-                            "value": "[gG][lL][oO][bB][aA][lL]"
+                            "value": "global",
+                            "flags": "i"
                           },
                           "named": false,
                           "value": "global"
@@ -1330,7 +1369,8 @@
                           "type": "ALIAS",
                           "content": {
                             "type": "PATTERN",
-                            "value": "[dD][eE][vV][iI][cC][eE]"
+                            "value": "device",
+                            "flags": "i"
                           },
                           "named": false,
                           "value": "device"
@@ -1339,7 +1379,8 @@
                           "type": "ALIAS",
                           "content": {
                             "type": "PATTERN",
-                            "value": "[hH][oO][sS][tT]"
+                            "value": "host",
+                            "flags": "i"
                           },
                           "named": false,
                           "value": "host"
@@ -1348,7 +1389,8 @@
                           "type": "ALIAS",
                           "content": {
                             "type": "PATTERN",
-                            "value": "[gG][rR][iI][dD]_[gG][lL][oO][bB][aA][lL]"
+                            "value": "grid_global",
+                            "flags": "i"
                           },
                           "named": false,
                           "value": "grid_global"
@@ -1383,14 +1425,16 @@
                   "members": [
                     {
                       "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
+                      "value": "end",
+                      "flags": "i"
                     },
                     {
                       "type": "CHOICE",
                       "members": [
                         {
                           "type": "PATTERN",
-                          "value": "[fF][uU][nN][cC][tT][iI][oO][nN]"
+                          "value": "function",
+                          "flags": "i"
                         },
                         {
                           "type": "BLANK"
@@ -1401,7 +1445,8 @@
                 },
                 {
                   "type": "PATTERN",
-                  "value": "[eE][nN][dD][fF][uU][nN][cC][tT][iI][oO][nN]"
+                  "value": "endfunction",
+                  "flags": "i"
                 }
               ]
             },
@@ -1434,7 +1479,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[rR][eE][sS][uU][lL][tT]"
+            "value": "result",
+            "flags": "i"
           },
           "named": false,
           "value": "result"
@@ -1559,7 +1605,8 @@
       "type": "ALIAS",
       "content": {
         "type": "PATTERN",
-        "value": "[cC][oO][nN][tT][aA][iI][nN][sS]"
+        "value": "contains",
+        "flags": "i"
       },
       "named": false,
       "value": "contains"
@@ -1799,7 +1846,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[uU][sS][eE]"
+            "value": "use",
+            "flags": "i"
           },
           "named": false,
           "value": "use"
@@ -1824,7 +1872,8 @@
                           "type": "ALIAS",
                           "content": {
                             "type": "PATTERN",
-                            "value": "[iI][nN][tT][rR][iI][nN][sS][iI][cC]"
+                            "value": "intrinsic",
+                            "flags": "i"
                           },
                           "named": false,
                           "value": "intrinsic"
@@ -1833,7 +1882,8 @@
                           "type": "ALIAS",
                           "content": {
                             "type": "PATTERN",
-                            "value": "[nN][oO][nN]_[iI][nN][tT][rR][iI][nN][sS][iI][cC]"
+                            "value": "non_intrinsic",
+                            "flags": "i"
                           },
                           "named": false,
                           "value": "non_intrinsic"
@@ -1938,7 +1988,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[oO][nN][lL][yY]"
+            "value": "only",
+            "flags": "i"
           },
           "named": false,
           "value": "only"
@@ -2037,7 +2088,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[iI][mM][pP][lL][iI][cC][iI][tT]"
+            "value": "implicit",
+            "flags": "i"
           },
           "named": false,
           "value": "implicit"
@@ -2177,7 +2229,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "[nN][oO][nN][eE]"
+                    "value": "none",
+                    "flags": "i"
                   },
                   "named": true,
                   "value": "none"
@@ -2202,7 +2255,8 @@
                                   "type": "ALIAS",
                                   "content": {
                                     "type": "PATTERN",
-                                    "value": "[tT][yY][pP][eE]"
+                                    "value": "type",
+                                    "flags": "i"
                                   },
                                   "named": false,
                                   "value": "type"
@@ -2211,7 +2265,8 @@
                                   "type": "ALIAS",
                                   "content": {
                                     "type": "PATTERN",
-                                    "value": "[eE][xX][tT][eE][rR][nN][aA][lL]"
+                                    "value": "external",
+                                    "flags": "i"
                                   },
                                   "named": false,
                                   "value": "external"
@@ -2234,7 +2289,8 @@
                                         "type": "ALIAS",
                                         "content": {
                                           "type": "PATTERN",
-                                          "value": "[tT][yY][pP][eE]"
+                                          "value": "type",
+                                          "flags": "i"
                                         },
                                         "named": false,
                                         "value": "type"
@@ -2243,7 +2299,8 @@
                                         "type": "ALIAS",
                                         "content": {
                                           "type": "PATTERN",
-                                          "value": "[eE][xX][tT][eE][rR][nN][aA][lL]"
+                                          "value": "external",
+                                          "flags": "i"
                                         },
                                         "named": false,
                                         "value": "external"
@@ -2282,7 +2339,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[sS][aA][vV][eE]"
+              "value": "save",
+              "flags": "i"
             },
             "named": false,
             "value": "save"
@@ -2394,7 +2452,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[pP][rR][iI][vV][aA][tT][eE]"
+              "value": "private",
+              "flags": "i"
             },
             "named": false,
             "value": "private"
@@ -2472,7 +2531,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[pP][uU][bB][lL][iI][cC]"
+              "value": "public",
+              "flags": "i"
             },
             "named": false,
             "value": "public"
@@ -2547,7 +2607,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[nN][aA][mM][eE][lL][iI][sS][tT]"
+            "value": "namelist",
+            "flags": "i"
           },
           "named": false,
           "value": "namelist"
@@ -2568,7 +2629,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[cC][oO][mM][mM][oO][nN]"
+            "value": "common",
+            "flags": "i"
           },
           "named": false,
           "value": "common"
@@ -2694,7 +2756,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[iI][mM][pP][oO][rR][tT]"
+              "value": "import",
+              "flags": "i"
             },
             "named": false,
             "value": "import"
@@ -2776,7 +2839,8 @@
                       "type": "ALIAS",
                       "content": {
                         "type": "PATTERN",
-                        "value": "[oO][nN][lL][yY]"
+                        "value": "only",
+                        "flags": "i"
                       },
                       "named": false,
                       "value": "only"
@@ -2816,7 +2880,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "[nN][oO][nN][eE]"
+                    "value": "none",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "none"
@@ -2825,7 +2890,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "[aA][lL][lL]"
+                    "value": "all",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "all"
@@ -2879,7 +2945,8 @@
                     "type": "ALIAS",
                     "content": {
                       "type": "PATTERN",
-                      "value": "[sS][eE][qQ][uU][eE][nN][cC][eE]"
+                      "value": "sequence",
+                      "flags": "i"
                     },
                     "named": false,
                     "value": "sequence"
@@ -2945,7 +3012,8 @@
       "type": "ALIAS",
       "content": {
         "type": "PATTERN",
-        "value": "[aA][bB][sS][tT][rR][aA][cC][tT]"
+        "value": "abstract",
+        "flags": "i"
       },
       "named": false,
       "value": "abstract"
@@ -2957,7 +3025,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[pP][uU][bB][lL][iI][cC]"
+            "value": "public",
+            "flags": "i"
           },
           "named": false,
           "value": "public"
@@ -2966,7 +3035,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[pP][rR][iI][vV][aA][tT][eE]"
+            "value": "private",
+            "flags": "i"
           },
           "named": false,
           "value": "private"
@@ -2980,7 +3050,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[eE][xX][tT][eE][nN][dD][sS]"
+            "value": "extends",
+            "flags": "i"
           },
           "named": false,
           "value": "extends"
@@ -3047,7 +3118,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[tT][yY][pP][eE]"
+            "value": "type",
+            "flags": "i"
           },
           "named": false,
           "value": "type"
@@ -3142,14 +3214,16 @@
                   "members": [
                     {
                       "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
+                      "value": "end",
+                      "flags": "i"
                     },
                     {
                       "type": "CHOICE",
                       "members": [
                         {
                           "type": "PATTERN",
-                          "value": "[tT][yY][pP][eE]"
+                          "value": "type",
+                          "flags": "i"
                         },
                         {
                           "type": "BLANK"
@@ -3160,7 +3234,8 @@
                 },
                 {
                   "type": "PATTERN",
-                  "value": "[eE][nN][dD][tT][yY][pP][eE]"
+                  "value": "endtype",
+                  "flags": "i"
                 }
               ]
             },
@@ -3426,7 +3501,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[gG][eE][nN][eE][rR][iI][cC]"
+            "value": "generic",
+            "flags": "i"
           },
           "named": false,
           "value": "generic"
@@ -3435,7 +3511,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[iI][nN][iI][tT][iI][aA][lL]"
+            "value": "initial",
+            "flags": "i"
           },
           "named": false,
           "value": "initial"
@@ -3444,7 +3521,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[pP][rR][oO][cC][eE][dD][uU][rR][eE]"
+            "value": "procedure",
+            "flags": "i"
           },
           "named": false,
           "value": "procedure"
@@ -3456,7 +3534,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[mM][oO][dD][uU][lL][eE]"
+                "value": "module",
+                "flags": "i"
               },
               "named": false,
               "value": "module"
@@ -3465,7 +3544,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[pP][rR][oO][cC][eE][dD][uU][rR][eE]"
+                "value": "procedure",
+                "flags": "i"
               },
               "named": false,
               "value": "procedure"
@@ -3476,7 +3556,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[pP][rR][oO][pP][eE][rR][tT][yY]"
+            "value": "property",
+            "flags": "i"
           },
           "named": false,
           "value": "property"
@@ -3485,7 +3566,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[fF][iI][nN][aA][lL]"
+            "value": "final",
+            "flags": "i"
           },
           "named": false,
           "value": "final"
@@ -3502,7 +3584,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[dD][eE][fF][eE][rR][rR][eE][dD]"
+              "value": "deferred",
+              "flags": "i"
             },
             "named": false,
             "value": "deferred"
@@ -3514,7 +3597,8 @@
                 "type": "ALIAS",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[pP][aA][sS][sS]"
+                  "value": "pass",
+                  "flags": "i"
                 },
                 "named": false,
                 "value": "pass"
@@ -3550,7 +3634,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[nN][oO][pP][aA][sS][sS]"
+              "value": "nopass",
+              "flags": "i"
             },
             "named": false,
             "value": "nopass"
@@ -3559,7 +3644,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[nN][oO][nN]_[oO][vV][eE][rR][rR][iI][dD][aA][bB][lL][eE]"
+              "value": "non_overridable",
+              "flags": "i"
             },
             "named": false,
             "value": "non_overridable"
@@ -3568,7 +3654,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[pP][uU][bB][lL][iI][cC]"
+              "value": "public",
+              "flags": "i"
             },
             "named": false,
             "value": "public"
@@ -3577,7 +3664,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[pP][rR][iI][vV][aA][tT][eE]"
+              "value": "private",
+              "flags": "i"
             },
             "named": false,
             "value": "private"
@@ -3586,7 +3674,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[fF][aA][mM][iI][lL][yY]"
+              "value": "family",
+              "flags": "i"
             },
             "named": false,
             "value": "family"
@@ -3595,7 +3684,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[pP][oO][iI][nN][tT][eE][rR]"
+              "value": "pointer",
+              "flags": "i"
             },
             "named": false,
             "value": "pointer"
@@ -3695,7 +3785,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[pP][rR][oO][cC][eE][dD][uU][rR][eE]"
+            "value": "procedure",
+            "flags": "i"
           },
           "named": false,
           "value": "procedure"
@@ -3826,7 +3917,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[aA][tT][tT][rR][iI][bB][uU][tT][eE][sS]"
+            "value": "attributes",
+            "flags": "i"
           },
           "named": false,
           "value": "attributes"
@@ -3842,7 +3934,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[dD][eE][vV][iI][cC][eE]"
+                "value": "device",
+                "flags": "i"
               },
               "named": false,
               "value": "device"
@@ -3851,7 +3944,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[mM][aA][nN][aA][gG][eE][dD]"
+                "value": "managed",
+                "flags": "i"
               },
               "named": false,
               "value": "managed"
@@ -3860,7 +3954,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[cC][oO][nN][sS][tT][aA][nN][tT]"
+                "value": "constant",
+                "flags": "i"
               },
               "named": false,
               "value": "constant"
@@ -3869,7 +3964,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[sS][hH][aA][rR][eE][dD]"
+                "value": "shared",
+                "flags": "i"
               },
               "named": false,
               "value": "shared"
@@ -3878,7 +3974,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[pP][iI][nN][nN][eE][dD]"
+                "value": "pinned",
+                "flags": "i"
               },
               "named": false,
               "value": "pinned"
@@ -3887,7 +3984,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[tT][eE][xX][tT][uU][rR][eE]"
+                "value": "texture",
+                "flags": "i"
               },
               "named": false,
               "value": "texture"
@@ -4025,7 +4123,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[bB][yY][tT][eE]"
+            "value": "byte",
+            "flags": "i"
           },
           "named": false,
           "value": "byte"
@@ -4034,7 +4133,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[iI][nN][tT][eE][gG][eE][rR]"
+            "value": "integer",
+            "flags": "i"
           },
           "named": false,
           "value": "integer"
@@ -4043,7 +4143,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[rR][eE][aA][lL]"
+            "value": "real",
+            "flags": "i"
           },
           "named": false,
           "value": "real"
@@ -4058,17 +4159,20 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[dD][oO][uU][bB][lL][eE]"
+                    "value": "double",
+                    "flags": "i"
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[pP][rR][eE][cC][iI][sS][iI][oO][nN]"
+                    "value": "precision",
+                    "flags": "i"
                   }
                 ]
               },
               {
                 "type": "PATTERN",
-                "value": "[dD][oO][uU][bB][lL][eE][pP][rR][eE][cC][iI][sS][iI][oO][nN]"
+                "value": "doubleprecision",
+                "flags": "i"
               }
             ]
           },
@@ -4079,7 +4183,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[cC][oO][mM][pP][lL][eE][xX]"
+            "value": "complex",
+            "flags": "i"
           },
           "named": false,
           "value": "complex"
@@ -4094,17 +4199,20 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[dD][oO][uU][bB][lL][eE]"
+                    "value": "double",
+                    "flags": "i"
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[cC][oO][mM][pP][lL][eE][xX]"
+                    "value": "complex",
+                    "flags": "i"
                   }
                 ]
               },
               {
                 "type": "PATTERN",
-                "value": "[dD][oO][uU][bB][lL][eE][cC][oO][mM][pP][lL][eE][xX]"
+                "value": "doublecomplex",
+                "flags": "i"
               }
             ]
           },
@@ -4115,7 +4223,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[lL][oO][gG][iI][cC][aA][lL]"
+            "value": "logical",
+            "flags": "i"
           },
           "named": false,
           "value": "logical"
@@ -4124,7 +4233,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[cC][hH][aA][rR][aA][cC][tT][eE][rR]"
+            "value": "character",
+            "flags": "i"
           },
           "named": false,
           "value": "character"
@@ -4141,7 +4251,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[tT][yY][pP][eE]"
+                "value": "type",
+                "flags": "i"
               },
               "named": false,
               "value": "type"
@@ -4150,7 +4261,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[cC][lL][aA][sS][sS]"
+                "value": "class",
+                "flags": "i"
               },
               "named": false,
               "value": "class"
@@ -4298,7 +4410,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[aA][bB][sS][tT][rR][aA][cC][tT]"
+            "value": "abstract",
+            "flags": "i"
           },
           "named": false,
           "value": "abstract"
@@ -4307,7 +4420,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[aA][lL][lL][oO][cC][aA][tT][aA][bB][lL][eE]"
+            "value": "allocatable",
+            "flags": "i"
           },
           "named": false,
           "value": "allocatable"
@@ -4316,7 +4430,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[aA][uU][tT][oO][mM][aA][tT][iI][cC]"
+            "value": "automatic",
+            "flags": "i"
           },
           "named": false,
           "value": "automatic"
@@ -4331,7 +4446,8 @@
                 "type": "ALIAS",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[dD][iI][mM][eE][nN][sS][iI][oO][nN]"
+                  "value": "dimension",
+                  "flags": "i"
                 },
                 "named": false,
                 "value": "dimension"
@@ -4355,7 +4471,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[cC][oO][nN][sS][tT][aA][nN][tT]"
+            "value": "constant",
+            "flags": "i"
           },
           "named": false,
           "value": "constant"
@@ -4364,7 +4481,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[cC][oO][nN][tT][iI][gG][uU][oO][uU][sS]"
+            "value": "contiguous",
+            "flags": "i"
           },
           "named": false,
           "value": "contiguous"
@@ -4373,7 +4491,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[dD][eE][vV][iI][cC][eE]"
+            "value": "device",
+            "flags": "i"
           },
           "named": false,
           "value": "device"
@@ -4382,7 +4501,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[eE][xX][tT][eE][rR][nN][aA][lL]"
+            "value": "external",
+            "flags": "i"
           },
           "named": false,
           "value": "external"
@@ -4394,7 +4514,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[iI][nN][tT][eE][nN][tT]"
+                "value": "intent",
+                "flags": "i"
               },
               "named": false,
               "value": "intent"
@@ -4410,7 +4531,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "[iI][nN]"
+                    "value": "in",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "in"
@@ -4419,7 +4541,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "[oO][uU][tT]"
+                    "value": "out",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "out"
@@ -4434,17 +4557,20 @@
                         "members": [
                           {
                             "type": "PATTERN",
-                            "value": "[iI][nN]"
+                            "value": "in",
+                            "flags": "i"
                           },
                           {
                             "type": "PATTERN",
-                            "value": "[oO][uU][tT]"
+                            "value": "out",
+                            "flags": "i"
                           }
                         ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "[iI][nN][oO][uU][tT]"
+                        "value": "inout",
+                        "flags": "i"
                       }
                     ]
                   },
@@ -4463,7 +4589,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[iI][nN][tT][rR][iI][nN][sS][iI][cC]"
+            "value": "intrinsic",
+            "flags": "i"
           },
           "named": false,
           "value": "intrinsic"
@@ -4472,7 +4599,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[mM][aA][nN][aA][gG][eE][dD]"
+            "value": "managed",
+            "flags": "i"
           },
           "named": false,
           "value": "managed"
@@ -4481,7 +4609,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[oO][pP][tT][iI][oO][nN][aA][lL]"
+            "value": "optional",
+            "flags": "i"
           },
           "named": false,
           "value": "optional"
@@ -4490,7 +4619,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[pP][aA][rR][aA][mM][eE][tT][eE][rR]"
+            "value": "parameter",
+            "flags": "i"
           },
           "named": false,
           "value": "parameter"
@@ -4499,7 +4629,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[pP][iI][nN][nN][eE][dD]"
+            "value": "pinned",
+            "flags": "i"
           },
           "named": false,
           "value": "pinned"
@@ -4508,7 +4639,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[pP][oO][iI][nN][tT][eE][rR]"
+            "value": "pointer",
+            "flags": "i"
           },
           "named": false,
           "value": "pointer"
@@ -4517,7 +4649,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[pP][rR][iI][vV][aA][tT][eE]"
+            "value": "private",
+            "flags": "i"
           },
           "named": false,
           "value": "private"
@@ -4526,7 +4659,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[pP][rR][oO][tT][eE][cC][tT][eE][dD]"
+            "value": "protected",
+            "flags": "i"
           },
           "named": false,
           "value": "protected"
@@ -4535,7 +4669,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[pP][uU][bB][lL][iI][cC]"
+            "value": "public",
+            "flags": "i"
           },
           "named": false,
           "value": "public"
@@ -4544,7 +4679,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[sS][aA][vV][eE]"
+            "value": "save",
+            "flags": "i"
           },
           "named": false,
           "value": "save"
@@ -4553,7 +4689,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[sS][eE][qQ][uU][eE][nN][cC][eE]"
+            "value": "sequence",
+            "flags": "i"
           },
           "named": false,
           "value": "sequence"
@@ -4562,7 +4699,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[sS][hH][aA][rR][eE][dD]"
+            "value": "shared",
+            "flags": "i"
           },
           "named": false,
           "value": "shared"
@@ -4571,7 +4709,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[sS][tT][aA][tT][iI][cC]"
+            "value": "static",
+            "flags": "i"
           },
           "named": false,
           "value": "static"
@@ -4580,7 +4719,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[tT][aA][rR][gG][eE][tT]"
+            "value": "target",
+            "flags": "i"
           },
           "named": false,
           "value": "target"
@@ -4589,7 +4729,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[tT][eE][xX][tT][uU][rR][eE]"
+            "value": "texture",
+            "flags": "i"
           },
           "named": false,
           "value": "texture"
@@ -4598,7 +4739,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[vV][aA][lL][uU][eE]"
+            "value": "value",
+            "flags": "i"
           },
           "named": false,
           "value": "value"
@@ -4607,7 +4749,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[vV][oO][lL][aA][tT][iI][lL][eE]"
+            "value": "volatile",
+            "flags": "i"
           },
           "named": false,
           "value": "volatile"
@@ -4621,7 +4764,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[eE][lL][eE][mM][eE][nN][tT][aA][lL]"
+            "value": "elemental",
+            "flags": "i"
           },
           "named": false,
           "value": "elemental"
@@ -4630,7 +4774,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[iI][mM][pP][uU][rR][eE]"
+            "value": "impure",
+            "flags": "i"
           },
           "named": false,
           "value": "impure"
@@ -4639,7 +4784,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[mM][oO][dD][uU][lL][eE]"
+            "value": "module",
+            "flags": "i"
           },
           "named": false,
           "value": "module"
@@ -4648,7 +4794,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[pP][uU][rR][eE]"
+            "value": "pure",
+            "flags": "i"
           },
           "named": false,
           "value": "pure"
@@ -4657,7 +4804,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[rR][eE][cC][uU][rR][sS][iI][vV][eE]"
+            "value": "recursive",
+            "flags": "i"
           },
           "named": false,
           "value": "recursive"
@@ -4674,7 +4822,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[pP][aA][rR][aA][mM][eE][tT][eE][rR]"
+              "value": "parameter",
+              "flags": "i"
             },
             "named": false,
             "value": "parameter"
@@ -4739,7 +4888,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[eE][qQ][uU][iI][vV][aA][lL][eE][nN][cC][eE]"
+            "value": "equivalence",
+            "flags": "i"
           },
           "named": false,
           "value": "equivalence"
@@ -5010,7 +5160,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[eE][rR][rR][oO][rR]"
+                "value": "error",
+                "flags": "i"
               },
               "named": false,
               "value": "error"
@@ -5024,7 +5175,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[sS][tT][oO][pP]"
+            "value": "stop",
+            "flags": "i"
           },
           "named": false,
           "value": "stop"
@@ -5061,7 +5213,8 @@
                         "type": "ALIAS",
                         "content": {
                           "type": "PATTERN",
-                          "value": "[qQ][uU][iI][eE][tT]"
+                          "value": "quiet",
+                          "flags": "i"
                         },
                         "named": false,
                         "value": "quiet"
@@ -5146,7 +5299,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[cC][aA][lL][lL]"
+              "value": "call",
+              "flags": "i"
             },
             "named": false,
             "value": "call"
@@ -5231,7 +5385,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[cC][oO][nN][tT][iI][nN][uU][eE]"
+            "value": "continue",
+            "flags": "i"
           },
           "named": false,
           "value": "continue"
@@ -5243,7 +5398,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[cC][yY][cC][lL][eE]"
+                "value": "cycle",
+                "flags": "i"
               },
               "named": false,
               "value": "cycle"
@@ -5269,7 +5425,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[eE][xX][iI][tT]"
+                "value": "exit",
+                "flags": "i"
               },
               "named": false,
               "value": "exit"
@@ -5301,17 +5458,20 @@
                     "members": [
                       {
                         "type": "PATTERN",
-                        "value": "[gG][oO]"
+                        "value": "go",
+                        "flags": "i"
                       },
                       {
                         "type": "PATTERN",
-                        "value": "[tT][oO]"
+                        "value": "to",
+                        "flags": "i"
                       }
                     ]
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[gG][oO][tT][oO]"
+                    "value": "goto",
+                    "flags": "i"
                   }
                 ]
               },
@@ -5387,7 +5547,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[rR][eE][tT][uU][rR][nN]"
+            "value": "return",
+            "flags": "i"
           },
           "named": false,
           "value": "return"
@@ -5401,7 +5562,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[iI][nN][cC][lL][uU][dD][eE]"
+            "value": "include",
+            "flags": "i"
           },
           "named": false,
           "value": "include"
@@ -5431,7 +5593,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[dD][aA][tT][aA]"
+              "value": "data",
+              "flags": "i"
             },
             "named": false,
             "value": "data"
@@ -5727,7 +5890,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[dD][oO]"
+            "value": "do",
+            "flags": "i"
           },
           "named": false,
           "value": "do"
@@ -5805,7 +5969,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[dD][oO]"
+            "value": "do",
+            "flags": "i"
           },
           "named": false,
           "value": "do"
@@ -5845,17 +6010,20 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
+                    "value": "end",
+                    "flags": "i"
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[dD][oO]"
+                    "value": "do",
+                    "flags": "i"
                   }
                 ]
               },
               {
                 "type": "PATTERN",
-                "value": "[eE][nN][dD][dD][oO]"
+                "value": "enddo",
+                "flags": "i"
               }
             ]
           },
@@ -5883,7 +6051,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[wW][hH][iI][lL][eE]"
+            "value": "while",
+            "flags": "i"
           },
           "named": false,
           "value": "while"
@@ -5917,7 +6086,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[cC][oO][nN][cC][uU][rR][rR][eE][nN][tT]"
+            "value": "concurrent",
+            "flags": "i"
           },
           "named": false,
           "value": "concurrent"
@@ -6079,7 +6249,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "[lL][oO][cC][aA][lL]"
+                    "value": "local",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "local"
@@ -6088,7 +6259,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "[lL][oO][cC][aA][lL]_[iI][nN][iI][tT]"
+                    "value": "local_init",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "local_init"
@@ -6097,7 +6269,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "[sS][hH][aA][rR][eE][dD]"
+                    "value": "shared",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "shared"
@@ -6146,7 +6319,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[dD][eE][fF][aA][uU][lL][tT]"
+                "value": "default",
+                "flags": "i"
               },
               "named": false,
               "value": "default"
@@ -6159,7 +6333,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[nN][oO][nN][eE]"
+                "value": "none",
+                "flags": "i"
               },
               "named": false,
               "value": "none"
@@ -6195,7 +6370,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[iI][fF]"
+              "value": "if",
+              "flags": "i"
             },
             "named": false,
             "value": "if"
@@ -6221,7 +6397,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[iI][fF]"
+              "value": "if",
+              "flags": "i"
             },
             "named": false,
             "value": "if"
@@ -6272,7 +6449,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[iI][fF]"
+            "value": "if",
+            "flags": "i"
           },
           "named": false,
           "value": "if"
@@ -6285,7 +6463,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[tT][hH][eE][nN]"
+            "value": "then",
+            "flags": "i"
           },
           "named": false,
           "value": "then"
@@ -6363,17 +6542,20 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
+                    "value": "end",
+                    "flags": "i"
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[iI][fF]"
+                    "value": "if",
+                    "flags": "i"
                   }
                 ]
               },
               {
                 "type": "PATTERN",
-                "value": "[eE][nN][dD][iI][fF]"
+                "value": "endif",
+                "flags": "i"
               }
             ]
           },
@@ -6407,17 +6589,20 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[eE][lL][sS][eE]"
+                    "value": "else",
+                    "flags": "i"
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[iI][fF]"
+                    "value": "if",
+                    "flags": "i"
                   }
                 ]
               },
               {
                 "type": "PATTERN",
-                "value": "[eE][lL][sS][eE][iI][fF]"
+                "value": "elseif",
+                "flags": "i"
               }
             ]
           },
@@ -6432,7 +6617,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[tT][hH][eE][nN]"
+            "value": "then",
+            "flags": "i"
           },
           "named": false,
           "value": "then"
@@ -6469,7 +6655,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[eE][lL][sS][eE]"
+            "value": "else",
+            "flags": "i"
           },
           "named": false,
           "value": "else"
@@ -6522,7 +6709,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[wW][hH][eE][rR][eE]"
+              "value": "where",
+              "flags": "i"
             },
             "named": false,
             "value": "where"
@@ -6557,7 +6745,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[wW][hH][eE][rR][eE]"
+            "value": "where",
+            "flags": "i"
           },
           "named": false,
           "value": "where"
@@ -6603,17 +6792,20 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
+                    "value": "end",
+                    "flags": "i"
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[wW][hH][eE][rR][eE]"
+                    "value": "where",
+                    "flags": "i"
                   }
                 ]
               },
               {
                 "type": "PATTERN",
-                "value": "[eE][nN][dD][wW][hH][eE][rR][eE]"
+                "value": "endwhere",
+                "flags": "i"
               }
             ]
           },
@@ -6647,17 +6839,20 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[eE][lL][sS][eE]"
+                    "value": "else",
+                    "flags": "i"
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[wW][hH][eE][rR][eE]"
+                    "value": "where",
+                    "flags": "i"
                   }
                 ]
               },
               {
                 "type": "PATTERN",
-                "value": "[eE][lL][sS][eE][wW][hH][eE][rR][eE]"
+                "value": "elsewhere",
+                "flags": "i"
               }
             ]
           },
@@ -6767,7 +6962,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[fF][oO][rR][aA][lL][lL]"
+            "value": "forall",
+            "flags": "i"
           },
           "named": false,
           "value": "forall"
@@ -6911,17 +7107,20 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
+                    "value": "end",
+                    "flags": "i"
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[fF][oO][rR][aA][lL][lL]"
+                    "value": "forall",
+                    "flags": "i"
                   }
                 ]
               },
               {
                 "type": "PATTERN",
-                "value": "[eE][nN][dD][fF][oO][rR][aA][lL][lL]"
+                "value": "endforall",
+                "flags": "i"
               }
             ]
           },
@@ -6967,17 +7166,20 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[sS][eE][lL][eE][cC][tT]"
+                    "value": "select",
+                    "flags": "i"
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[cC][aA][sS][eE]"
+                    "value": "case",
+                    "flags": "i"
                   }
                 ]
               },
               {
                 "type": "PATTERN",
-                "value": "[sS][eE][lL][eE][cC][tT][cC][aA][sS][eE]"
+                "value": "selectcase",
+                "flags": "i"
               }
             ]
           },
@@ -7042,17 +7244,20 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[sS][eE][lL][eE][cC][tT]"
+                    "value": "select",
+                    "flags": "i"
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[tT][yY][pP][eE]"
+                    "value": "type",
+                    "flags": "i"
                   }
                 ]
               },
               {
                 "type": "PATTERN",
-                "value": "[sS][eE][lL][eE][cC][tT][tT][yY][pP][eE]"
+                "value": "selecttype",
+                "flags": "i"
               }
             ]
           },
@@ -7117,17 +7322,20 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[sS][eE][lL][eE][cC][tT]"
+                    "value": "select",
+                    "flags": "i"
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[rR][aA][nN][kK]"
+                    "value": "rank",
+                    "flags": "i"
                   }
                 ]
               },
               {
                 "type": "PATTERN",
-                "value": "[sS][eE][lL][eE][cC][tT][rR][aA][nN][kK]"
+                "value": "selectrank",
+                "flags": "i"
               }
             ]
           },
@@ -7180,17 +7388,20 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
+                    "value": "end",
+                    "flags": "i"
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[sS][eE][lL][eE][cC][tT]"
+                    "value": "select",
+                    "flags": "i"
                   }
                 ]
               },
               {
                 "type": "PATTERN",
-                "value": "[eE][nN][dD][sS][eE][lL][eE][cC][tT]"
+                "value": "endselect",
+                "flags": "i"
               }
             ]
           },
@@ -7244,7 +7455,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[cC][aA][sS][eE]"
+            "value": "case",
+            "flags": "i"
           },
           "named": false,
           "value": "case"
@@ -7275,7 +7487,8 @@
                 "type": "ALIAS",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[dD][eE][fF][aA][uU][lL][tT]"
+                  "value": "default",
+                  "flags": "i"
                 },
                 "named": false,
                 "value": "default"
@@ -7332,17 +7545,20 @@
                             "members": [
                               {
                                 "type": "PATTERN",
-                                "value": "[tT][yY][pP][eE]"
+                                "value": "type",
+                                "flags": "i"
                               },
                               {
                                 "type": "PATTERN",
-                                "value": "[iI][sS]"
+                                "value": "is",
+                                "flags": "i"
                               }
                             ]
                           },
                           {
                             "type": "PATTERN",
-                            "value": "[tT][yY][pP][eE][iI][sS]"
+                            "value": "typeis",
+                            "flags": "i"
                           }
                         ]
                       },
@@ -7359,17 +7575,20 @@
                             "members": [
                               {
                                 "type": "PATTERN",
-                                "value": "[cC][lL][aA][sS][sS]"
+                                "value": "class",
+                                "flags": "i"
                               },
                               {
                                 "type": "PATTERN",
-                                "value": "[iI][sS]"
+                                "value": "is",
+                                "flags": "i"
                               }
                             ]
                           },
                           {
                             "type": "PATTERN",
-                            "value": "[cC][lL][aA][sS][sS][iI][sS]"
+                            "value": "classis",
+                            "flags": "i"
                           }
                         ]
                       },
@@ -7459,17 +7678,20 @@
           "members": [
             {
               "type": "PATTERN",
-              "value": "[cC][lL][aA][sS][sS]"
+              "value": "class",
+              "flags": "i"
             },
             {
               "type": "PATTERN",
-              "value": "[dD][eE][fF][aA][uU][lL][tT]"
+              "value": "default",
+              "flags": "i"
             }
           ]
         },
         {
           "type": "PATTERN",
-          "value": "[cC][lL][aA][sS][sS][dD][eE][fF][aA][uU][lL][tT]"
+          "value": "classdefault",
+          "flags": "i"
         }
       ]
     },
@@ -7523,7 +7745,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[rR][aA][nN][kK]"
+            "value": "rank",
+            "flags": "i"
           },
           "named": false,
           "value": "rank"
@@ -7554,7 +7777,8 @@
                 "type": "ALIAS",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[dD][eE][fF][aA][uU][lL][tT]"
+                  "value": "default",
+                  "flags": "i"
                 },
                 "named": false,
                 "value": "default"
@@ -7608,7 +7832,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[bB][lL][oO][cC][kK]"
+            "value": "block",
+            "flags": "i"
           },
           "named": false,
           "value": "block"
@@ -7650,17 +7875,20 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
+                    "value": "end",
+                    "flags": "i"
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[bB][lL][oO][cC][kK]"
+                    "value": "block",
+                    "flags": "i"
                   }
                 ]
               },
               {
                 "type": "PATTERN",
-                "value": "[eE][nN][dD][bB][lL][oO][cC][kK]"
+                "value": "endblock",
+                "flags": "i"
               }
             ]
           },
@@ -7700,7 +7928,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[aA][sS][sS][oO][cC][iI][aA][tT][eE]"
+            "value": "associate",
+            "flags": "i"
           },
           "named": false,
           "value": "associate"
@@ -7793,17 +8022,20 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
+                    "value": "end",
+                    "flags": "i"
                   },
                   {
                     "type": "PATTERN",
-                    "value": "[aA][sS][sS][oO][cC][iI][aA][tT][eE]"
+                    "value": "associate",
+                    "flags": "i"
                   }
                 ]
               },
               {
                 "type": "PATTERN",
-                "value": "[eE][nN][dD][aA][sS][sS][oO][cC][iI][aA][tT][eE]"
+                "value": "endassociate",
+                "flags": "i"
               }
             ]
           },
@@ -7834,7 +8066,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[fF][oO][rR][mM][aA][tT]"
+              "value": "format",
+              "flags": "i"
             },
             "named": false,
             "value": "format"
@@ -8113,7 +8346,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[rR][eE][aA][dD]"
+              "value": "read",
+              "flags": "i"
             },
             "named": false,
             "value": "read"
@@ -8156,7 +8390,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[rR][eE][aA][dD]"
+              "value": "read",
+              "flags": "i"
             },
             "named": false,
             "value": "read"
@@ -8187,7 +8422,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[pP][rR][iI][nN][tT]"
+            "value": "print",
+            "flags": "i"
           },
           "named": false,
           "value": "print"
@@ -8226,7 +8462,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[oO][pP][eE][nN]"
+            "value": "open",
+            "flags": "i"
           },
           "named": false,
           "value": "open"
@@ -8259,7 +8496,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[cC][lL][oO][sS][eE]"
+              "value": "close",
+              "flags": "i"
             },
             "named": false,
             "value": "close"
@@ -8357,7 +8595,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[wW][rR][iI][tT][eE]"
+              "value": "write",
+              "flags": "i"
             },
             "named": false,
             "value": "write"
@@ -8403,7 +8642,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[iI][nN][qQ][uU][iI][rR][eE]"
+              "value": "inquire",
+              "flags": "i"
             },
             "named": false,
             "value": "inquire"
@@ -8458,7 +8698,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[eE][nN][uU][mM]"
+            "value": "enum",
+            "flags": "i"
           },
           "named": false,
           "value": "enum"
@@ -8480,7 +8721,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[eE][nN][uU][mM][eE][rR][aA][tT][oO][rR]"
+            "value": "enumerator",
+            "flags": "i"
           },
           "named": false,
           "value": "enumerator"
@@ -8596,17 +8838,20 @@
             "members": [
               {
                 "type": "PATTERN",
-                "value": "[eE][nN][dD]"
+                "value": "end",
+                "flags": "i"
               },
               {
                 "type": "PATTERN",
-                "value": "[eE][nN][uU][mM]"
+                "value": "enum",
+                "flags": "i"
               }
             ]
           },
           {
             "type": "PATTERN",
-            "value": "[eE][nN][dD][eE][nN][uU][mM]"
+            "value": "endenum",
+            "flags": "i"
           }
         ]
       },
@@ -8746,7 +8991,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[bB][aA][cC][kK][sS][pP][aA][cC][eE]"
+                "value": "backspace",
+                "flags": "i"
               },
               "named": false,
               "value": "backspace"
@@ -8764,7 +9010,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[eE][nN][dD][fF][iI][lL][eE]"
+                "value": "endfile",
+                "flags": "i"
               },
               "named": false,
               "value": "endfile"
@@ -8782,7 +9029,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[rR][eE][wW][iI][nN][dD]"
+                "value": "rewind",
+                "flags": "i"
               },
               "named": false,
               "value": "rewind"
@@ -8800,7 +9048,8 @@
               "type": "ALIAS",
               "content": {
                 "type": "PATTERN",
-                "value": "[pP][aA][uU][sS][eE]"
+                "value": "pause",
+                "flags": "i"
               },
               "named": false,
               "value": "pause"
@@ -9056,7 +9305,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "\\.[oO][rR]\\."
+                    "value": "\\.or\\.",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "\\.or\\."
@@ -9094,7 +9344,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "\\.[aA][nN][dD]\\."
+                    "value": "\\.and\\.",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "\\.and\\."
@@ -9132,7 +9383,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "\\.[eE][qQ][vV]\\."
+                    "value": "\\.eqv\\.",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "\\.eqv\\."
@@ -9170,7 +9422,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "\\.[nN][eE][qQ][vV]\\."
+                    "value": "\\.neqv\\.",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "\\.neqv\\."
@@ -9197,7 +9450,8 @@
                 "type": "ALIAS",
                 "content": {
                   "type": "PATTERN",
-                  "value": "\\.[nN][oO][tT]\\."
+                  "value": "\\.not\\.",
+                  "flags": "i"
                 },
                 "named": false,
                 "value": "\\.not\\."
@@ -9268,7 +9522,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "\\.[lL][tT]\\."
+                    "value": "\\.lt\\.",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "\\.lt\\."
@@ -9339,7 +9594,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "\\.[gG][tT]\\."
+                    "value": "\\.gt\\.",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "\\.gt\\."
@@ -9410,7 +9666,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "\\.[lL][eE]\\."
+                    "value": "\\.le\\.",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "\\.le\\."
@@ -9481,7 +9738,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "\\.[gG][eE]\\."
+                    "value": "\\.ge\\.",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "\\.ge\\."
@@ -9552,7 +9810,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "\\.[eE][qQ]\\."
+                    "value": "\\.eq\\.",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "\\.eq\\."
@@ -9623,7 +9882,8 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "PATTERN",
-                    "value": "\\.[nN][eE]\\."
+                    "value": "\\.ne\\.",
+                    "flags": "i"
                   },
                   "named": false,
                   "value": "\\.ne\\."
@@ -10493,7 +10753,8 @@
                 "type": "ALIAS",
                 "content": {
                   "type": "PATTERN",
-                  "value": "\\.[tT][rR][uU][eE]\\."
+                  "value": "\\.true\\.",
+                  "flags": "i"
                 },
                 "named": false,
                 "value": "\\.true\\."
@@ -10502,7 +10763,8 @@
                 "type": "ALIAS",
                 "content": {
                   "type": "PATTERN",
-                  "value": "\\.[fF][aA][lL][sS][eE]\\."
+                  "value": "\\.false\\.",
+                  "flags": "i"
                 },
                 "named": false,
                 "value": "\\.false\\."
@@ -10543,7 +10805,8 @@
             "type": "ALIAS",
             "content": {
               "type": "PATTERN",
-              "value": "[nN][uU][lL][lL]"
+              "value": "null",
+              "flags": "i"
             },
             "named": false,
             "value": "null"
@@ -10613,7 +10876,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[bB][lL][oO][cC][kK]"
+            "value": "block",
+            "flags": "i"
           },
           "named": false,
           "value": "block"
@@ -10622,7 +10886,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[bB][yY][tT][eE]"
+            "value": "byte",
+            "flags": "i"
           },
           "named": false,
           "value": "byte"
@@ -10631,7 +10896,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[cC][yY][cC][lL][eE]"
+            "value": "cycle",
+            "flags": "i"
           },
           "named": false,
           "value": "cycle"
@@ -10640,7 +10906,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[dD][aA][tT][aA]"
+            "value": "data",
+            "flags": "i"
           },
           "named": false,
           "value": "data"
@@ -10649,7 +10916,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[dD][oO][uU][bB][lL][eE]"
+            "value": "double",
+            "flags": "i"
           },
           "named": false,
           "value": "double"
@@ -10658,7 +10926,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[eE][lL][sS][eE][iI][fF]"
+            "value": "elseif",
+            "flags": "i"
           },
           "named": false,
           "value": "elseif"
@@ -10667,7 +10936,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[eE][nN][dD]"
+            "value": "end",
+            "flags": "i"
           },
           "named": false,
           "value": "end"
@@ -10676,7 +10946,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[eE][nN][dD][iI][fF]"
+            "value": "endif",
+            "flags": "i"
           },
           "named": false,
           "value": "endif"
@@ -10685,7 +10956,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[eE][rR][rR][oO][rR]"
+            "value": "error",
+            "flags": "i"
           },
           "named": false,
           "value": "error"
@@ -10694,7 +10966,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[eE][xX][iI][tT]"
+            "value": "exit",
+            "flags": "i"
           },
           "named": false,
           "value": "exit"
@@ -10703,7 +10976,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[fF][oO][rR][mM][aA][tT]"
+            "value": "format",
+            "flags": "i"
           },
           "named": false,
           "value": "format"
@@ -10712,7 +10986,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[iI][fF]"
+            "value": "if",
+            "flags": "i"
           },
           "named": false,
           "value": "if"
@@ -10721,7 +10996,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[iI][nN][qQ][uU][iI][rR][eE]"
+            "value": "inquire",
+            "flags": "i"
           },
           "named": false,
           "value": "inquire"
@@ -10730,7 +11006,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[nN][uU][lL][lL]"
+            "value": "null",
+            "flags": "i"
           },
           "named": false,
           "value": "null"
@@ -10739,7 +11016,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[rR][eE][aA][dD]"
+            "value": "read",
+            "flags": "i"
           },
           "named": false,
           "value": "read"
@@ -10748,7 +11026,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[rR][eE][aA][lL]"
+            "value": "real",
+            "flags": "i"
           },
           "named": false,
           "value": "real"
@@ -10757,7 +11036,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[sS][eE][lL][eE][cC][tT]"
+            "value": "select",
+            "flags": "i"
           },
           "named": false,
           "value": "select"
@@ -10766,7 +11046,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[sS][tT][oO][pP]"
+            "value": "stop",
+            "flags": "i"
           },
           "named": false,
           "value": "stop"
@@ -10775,7 +11056,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[tT][aA][rR][gG][eE][tT]"
+            "value": "target",
+            "flags": "i"
           },
           "named": false,
           "value": "target"
@@ -10784,7 +11066,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[vV][aA][lL][uU][eE]"
+            "value": "value",
+            "flags": "i"
           },
           "named": false,
           "value": "value"
@@ -10793,7 +11076,8 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[wW][rR][iI][tT][eE]"
+            "value": "write",
+            "flags": "i"
           },
           "named": false,
           "value": "write"
@@ -10816,10 +11100,6 @@
         ]
       }
     },
-    "_line_continuation": {
-      "type": "STRING",
-      "value": "&"
-    },
     "_semicolon": {
       "type": "STRING",
       "value": ";"
@@ -10839,8 +11119,8 @@
       "name": "comment"
     },
     {
-      "type": "SYMBOL",
-      "name": "_line_continuation"
+      "type": "STRING",
+      "value": "&"
     },
     {
       "type": "SYMBOL",
@@ -10851,11 +11131,6 @@
     [
       "_expression",
       "complex_literal"
-    ],
-    [
-      "_inline_if_statement",
-      "_block_if_statement",
-      "identifier"
     ],
     [
       "argument_list",
@@ -10886,10 +11161,6 @@
       "elsewhere_clause"
     ],
     [
-      "format_statement",
-      "identifier"
-    ],
-    [
       "interface_statement"
     ],
     [
@@ -10897,16 +11168,8 @@
       "identifier"
     ],
     [
-      "inquire_statement",
-      "identifier"
-    ],
-    [
       "module_statement",
       "procedure_qualifier"
-    ],
-    [
-      "null_literal",
-      "identifier"
     ],
     [
       "procedure_declaration"
@@ -10924,16 +11187,13 @@
     ],
     [
       "type_statement"
-    ],
-    [
-      "translation_unit"
     ]
   ],
   "precedences": [],
   "externals": [
     {
-      "type": "SYMBOL",
-      "name": "_line_continuation"
+      "type": "STRING",
+      "value": "&"
     },
     {
       "type": "SYMBOL",
@@ -10960,22 +11220,5 @@
     "_top_level_item",
     "_statement"
   ],
-  "supertypes": [],
-  "PREC": {
-    "ASSIGNMENT": -10,
-    "DEFAULT": 0,
-    "DEFINED_OPERATOR": 2,
-    "LOGICAL_EQUIV": 5,
-    "LOGICAL_OR": 10,
-    "LOGICAL_AND": 20,
-    "LOGICAL_NOT": 30,
-    "RELATIONAL": 40,
-    "ADDITIVE": 50,
-    "MULTIPLICATIVE": 60,
-    "EXPONENT": 70,
-    "CALL": 80,
-    "UNARY": 90,
-    "TYPE_MEMBER": 100
-  }
+  "supertypes": []
 }
-

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -7865,11 +7865,19 @@
     }
   },
   {
+    "type": "\n",
+    "named": false
+  },
+  {
     "type": "#",
     "named": false
   },
   {
     "type": "%",
+    "named": false
+  },
+  {
+    "type": "&",
     "named": false
   },
   {
@@ -7930,6 +7938,10 @@
   },
   {
     "type": "::",
+    "named": false
+  },
+  {
+    "type": ";",
     "named": false
   },
   {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,3 +1,4 @@
+#include "tree_sitter/alloc.h"
 #include "tree_sitter/parser.h"
 #include <ctype.h>
 #include <wctype.h>
@@ -338,7 +339,7 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
 }
 
 void *tree_sitter_fortran_external_scanner_create() {
-    return calloc(1, sizeof(bool));
+    return ts_calloc(1, sizeof(bool));
 }
 
 bool tree_sitter_fortran_external_scanner_scan(void *payload, TSLexer *lexer,
@@ -365,5 +366,5 @@ void tree_sitter_fortran_external_scanner_deserialize(void *payload,
 
 void tree_sitter_fortran_external_scanner_destroy(void *payload) {
     Scanner *scanner = (Scanner *)payload;
-    free(scanner);
+    ts_free(scanner);
 }

--- a/src/tree_sitter/alloc.h
+++ b/src/tree_sitter/alloc.h
@@ -1,0 +1,54 @@
+#ifndef TREE_SITTER_ALLOC_H_
+#define TREE_SITTER_ALLOC_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Allow clients to override allocation functions
+#ifdef TREE_SITTER_REUSE_ALLOCATOR
+
+extern void *(*ts_current_malloc)(size_t);
+extern void *(*ts_current_calloc)(size_t, size_t);
+extern void *(*ts_current_realloc)(void *, size_t);
+extern void (*ts_current_free)(void *);
+
+#ifndef ts_malloc
+#define ts_malloc  ts_current_malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  ts_current_calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc ts_current_realloc
+#endif
+#ifndef ts_free
+#define ts_free    ts_current_free
+#endif
+
+#else
+
+#ifndef ts_malloc
+#define ts_malloc  malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc realloc
+#endif
+#ifndef ts_free
+#define ts_free    free
+#endif
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_ALLOC_H_

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -1,0 +1,290 @@
+#ifndef TREE_SITTER_ARRAY_H_
+#define TREE_SITTER_ARRAY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "./alloc.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#pragma warning(disable : 4101)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
+#define Array(T)       \
+  struct {             \
+    T *contents;       \
+    uint32_t size;     \
+    uint32_t capacity; \
+  }
+
+/// Initialize an array.
+#define array_init(self) \
+  ((self)->size = 0, (self)->capacity = 0, (self)->contents = NULL)
+
+/// Create an empty array.
+#define array_new() \
+  { NULL, 0, 0 }
+
+/// Get a pointer to the element at a given `index` in the array.
+#define array_get(self, _index) \
+  (assert((uint32_t)(_index) < (self)->size), &(self)->contents[_index])
+
+/// Get a pointer to the first element in the array.
+#define array_front(self) array_get(self, 0)
+
+/// Get a pointer to the last element in the array.
+#define array_back(self) array_get(self, (self)->size - 1)
+
+/// Clear the array, setting its size to zero. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_clear(self) ((self)->size = 0)
+
+/// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
+/// less than the array's current capacity, this function has no effect.
+#define array_reserve(self, new_capacity) \
+  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
+
+/// Free any memory allocated for this array. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_delete(self) _array__delete((Array *)(self))
+
+/// Push a new `element` onto the end of the array.
+#define array_push(self, element)                            \
+  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
+   (self)->contents[(self)->size++] = (element))
+
+/// Increase the array's size by `count` elements.
+/// New elements are zero-initialized.
+#define array_grow_by(self, count) \
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
+
+/// Append all elements from one array to the end of another.
+#define array_push_all(self, other)                                       \
+  array_extend((self), (other)->size, (other)->contents)
+
+/// Append `count` elements to the end of the array, reading their values from the
+/// `contents` pointer.
+#define array_extend(self, count, contents)                    \
+  _array__splice(                                               \
+    (Array *)(self), array_elem_size(self), (self)->size, \
+    0, count,  contents                                        \
+  )
+
+/// Remove `old_count` elements from the array starting at the given `index`. At
+/// the same index, insert `new_count` new elements, reading their values from the
+/// `new_contents` pointer.
+#define array_splice(self, _index, old_count, new_count, new_contents)  \
+  _array__splice(                                                       \
+    (Array *)(self), array_elem_size(self), _index,                \
+    old_count, new_count, new_contents                                 \
+  )
+
+/// Insert one `element` into the array at the given `index`.
+#define array_insert(self, _index, element) \
+  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
+
+/// Remove one element from the array at the given `index`.
+#define array_erase(self, _index) \
+  _array__erase((Array *)(self), array_elem_size(self), _index)
+
+/// Pop the last element off the array, returning the element by value.
+#define array_pop(self) ((self)->contents[--(self)->size])
+
+/// Assign the contents of one array to another, reallocating if necessary.
+#define array_assign(self, other) \
+  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
+
+/// Swap one array with another
+#define array_swap(self, other) \
+  _array__swap((Array *)(self), (Array *)(other))
+
+/// Get the size of the array contents
+#define array_elem_size(self) (sizeof *(self)->contents)
+
+/// Search a sorted array for a given `needle` value, using the given `compare`
+/// callback to determine the order.
+///
+/// If an existing element is found to be equal to `needle`, then the `index`
+/// out-parameter is set to the existing value's index, and the `exists`
+/// out-parameter is set to true. Otherwise, `index` is set to an index where
+/// `needle` should be inserted in order to preserve the sorting, and `exists`
+/// is set to false.
+#define array_search_sorted_with(self, compare, needle, _index, _exists) \
+  _array__search_sorted(self, 0, compare, , needle, _index, _exists)
+
+/// Search a sorted array for a given `needle` value, using integer comparisons
+/// of a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_with`.
+#define array_search_sorted_by(self, field, needle, _index, _exists) \
+  _array__search_sorted(self, 0, _compare_int, field, needle, _index, _exists)
+
+/// Insert a given `value` into a sorted array, using the given `compare`
+/// callback to determine the order.
+#define array_insert_sorted_with(self, compare, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_with(self, compare, &(value), &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+/// Insert a given `value` into a sorted array, using integer comparisons of
+/// a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_by`.
+#define array_insert_sorted_by(self, field, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_by(self, field, (value) field, &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+// Private
+
+typedef Array(void) Array;
+
+/// This is not what you're looking for, see `array_delete`.
+static inline void _array__delete(Array *self) {
+  if (self->contents) {
+    ts_free(self->contents);
+    self->contents = NULL;
+    self->size = 0;
+    self->capacity = 0;
+  }
+}
+
+/// This is not what you're looking for, see `array_erase`.
+static inline void _array__erase(Array *self, size_t element_size,
+                                uint32_t index) {
+  assert(index < self->size);
+  char *contents = (char *)self->contents;
+  memmove(contents + index * element_size, contents + (index + 1) * element_size,
+          (self->size - index - 1) * element_size);
+  self->size--;
+}
+
+/// This is not what you're looking for, see `array_reserve`.
+static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
+  if (new_capacity > self->capacity) {
+    if (self->contents) {
+      self->contents = ts_realloc(self->contents, new_capacity * element_size);
+    } else {
+      self->contents = ts_malloc(new_capacity * element_size);
+    }
+    self->capacity = new_capacity;
+  }
+}
+
+/// This is not what you're looking for, see `array_assign`.
+static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
+  _array__reserve(self, element_size, other->size);
+  self->size = other->size;
+  memcpy(self->contents, other->contents, self->size * element_size);
+}
+
+/// This is not what you're looking for, see `array_swap`.
+static inline void _array__swap(Array *self, Array *other) {
+  Array swap = *other;
+  *other = *self;
+  *self = swap;
+}
+
+/// This is not what you're looking for, see `array_push` or `array_grow_by`.
+static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
+  uint32_t new_size = self->size + count;
+  if (new_size > self->capacity) {
+    uint32_t new_capacity = self->capacity * 2;
+    if (new_capacity < 8) new_capacity = 8;
+    if (new_capacity < new_size) new_capacity = new_size;
+    _array__reserve(self, element_size, new_capacity);
+  }
+}
+
+/// This is not what you're looking for, see `array_splice`.
+static inline void _array__splice(Array *self, size_t element_size,
+                                 uint32_t index, uint32_t old_count,
+                                 uint32_t new_count, const void *elements) {
+  uint32_t new_size = self->size + new_count - old_count;
+  uint32_t old_end = index + old_count;
+  uint32_t new_end = index + new_count;
+  assert(old_end <= self->size);
+
+  _array__reserve(self, element_size, new_size);
+
+  char *contents = (char *)self->contents;
+  if (self->size > old_end) {
+    memmove(
+      contents + new_end * element_size,
+      contents + old_end * element_size,
+      (self->size - old_end) * element_size
+    );
+  }
+  if (new_count > 0) {
+    if (elements) {
+      memcpy(
+        (contents + index * element_size),
+        elements,
+        new_count * element_size
+      );
+    } else {
+      memset(
+        (contents + index * element_size),
+        0,
+        new_count * element_size
+      );
+    }
+  }
+  self->size += new_count - old_count;
+}
+
+/// A binary search routine, based on Rust's `std::slice::binary_search_by`.
+/// This is not what you're looking for, see `array_search_sorted_with` or `array_search_sorted_by`.
+#define _array__search_sorted(self, start, compare, suffix, needle, _index, _exists) \
+  do { \
+    *(_index) = start; \
+    *(_exists) = false; \
+    uint32_t size = (self)->size - *(_index); \
+    if (size == 0) break; \
+    int comparison; \
+    while (size > 1) { \
+      uint32_t half_size = size / 2; \
+      uint32_t mid_index = *(_index) + half_size; \
+      comparison = compare(&((self)->contents[mid_index] suffix), (needle)); \
+      if (comparison <= 0) *(_index) = mid_index; \
+      size -= half_size; \
+    } \
+    comparison = compare(&((self)->contents[*(_index)] suffix), (needle)); \
+    if (comparison == 0) *(_exists) = true; \
+    else if (comparison < 0) *(_index) += 1; \
+  } while (0)
+
+/// Helper macro for the `_sorted_by` routines below. This takes the left (existing)
+/// parameter by reference in order to work with the generic sorting function above.
+#define _compare_int(a, b) ((int)*(a) - (int)(b))
+
+#ifdef _MSC_VER
+#pragma warning(default : 4101)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_ARRAY_H_

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,9 +13,8 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-typedef uint16_t TSStateId;
-
 #ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -87,6 +86,11 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -126,13 +130,38 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
 /*
  *  Lexer Macros
  */
 
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
+  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -146,6 +175,17 @@ struct TSLanguage {
   {                          \
     state = state_value;     \
     goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -166,7 +206,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) id - LARGE_STATE_COUNT
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
 
 #define STATE(id) id
 
@@ -176,7 +216,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value            \
+      .state = (state_value)          \
     }                                 \
   }}
 
@@ -184,7 +224,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value,           \
+      .state = (state_value),         \
       .repetition = true              \
     }                                 \
   }}
@@ -197,14 +237,15 @@ struct TSLanguage {
     }                                 \
   }}
 
-#define REDUCE(symbol_val, child_count_val, ...) \
-  {{                                             \
-    .reduce = {                                  \
-      .type = TSParseActionTypeReduce,           \
-      .symbol = symbol_val,                      \
-      .child_count = child_count_val,            \
-      __VA_ARGS__                                \
-    },                                           \
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
   }}
 
 #define RECOVER()                    \


### PR DESCRIPTION
Tree-sitter has had an update where hidden nodes consisting of just one terminal do not have the "absorption" feature that is silently present that you might have noticed. The problem is, with hidden nodes, this absorption does not allow the literal to be queried for, which was a pain point that was subtle but potentially inexplicable behavior. As such, we should just not have a node for this if we are concerned with a literal that is an anonymous node that is also an external - we can just directly reference this anonymous node if we want to hide it from the parse tree anyways (but still allow it to be queryable)