### PR TITLE
Updated to leverage tree-sitter ~0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "~0.20.10"
+tree-sitter = "~0.22.6"
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -6,7 +6,7 @@
 //! ```
 //! let code = "";
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_fortran::language()).expect("Error loading fortran grammar");
+//! parser.set_language(&tree_sitter_fortran::language()).expect("Error loading fortran grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! ```
 //!
@@ -46,7 +46,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
+            .set_language(&super::language())
             .expect("Error loading fortran language");
     }
 }


### PR DESCRIPTION
It only took a few quick changes to update the repo to work with more recent version of tree-sitter, that way comparing AST's with other languages (in mixed language formats), should work with a lot more ease. 