### PR TITLE
Add tree_sitter .h files to sdist so that it can build successfully

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+# Include the tree_sitter header files in the source distribution
+graft src/tree_sitter


### PR DESCRIPTION
The current sdist is missing the tree sitter header files and does not compile successfully:

```
python -m build
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - setuptools>=42
  - wheel
.......
gcc -DNDEBUG -g -fwrapv -O3 -Wall -O2 -ftree-vectorize -march=native -fno-math-errno -fPIC -O2 -ftree-vectorize -march=native -fno-math-errno -fPIC -fPIC -DPy_LIMITED_API=0x03080000 -DPY_SSIZE_T_CLEAN -Isrc -I/tmp/build-env-lyuzfcy0/include -I/opt/easybuild/software/Python/3.11.3-GCCcore-12.3.0/include/python3.11 -c src/parser.c -o build/temp.linux-x86_64-cpython-311/src/parser.o -std=c11
src/parser.c:1:10: fatal error: tree_sitter/parser.h: No such file or directory
    1 | #include "tree_sitter/parser.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
error: command '/opt/easybuild/software/GCCcore/12.3.0/bin/gcc' failed with exit code 1
```

Adding these to the MANIFEST.in correctly adds them to the source distribution and it can then be correctly built. 

This can then be pushed to pypi as the wheel is not needed:
https://github.com/byornski/tree-sitter-fortran/actions/runs/10582251449/job/29321516518

This has successfully pushed a tree-sitter-fortran-byornski package which installs and works correctly. I can push this as a further PR if it would help. 
