### PR TITLE
Add more F77/deprecated/obsolescent features

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -110,6 +110,7 @@ module.exports = grammar({
     [$.type_statement],
     [$.preproc_ifdef_in_specification_part, $.program],
     [$.preproc_else_in_specification_part, $.program],
+    [$.statement_function, $._expression],
   ],
 
   rules: {
@@ -496,6 +497,7 @@ module.exports = grammar({
       seq($.parameter_statement, $._end_of_statement),
       seq($.equivalence_statement, $._end_of_statement),
       seq($.data_statement, $._end_of_statement),
+      seq($.statement_function, $._end_of_statement),
       prec(1, seq($.statement_label, $.format_statement, $._end_of_statement)),
       $.preproc_include,
       $.preproc_def,
@@ -1570,6 +1572,16 @@ module.exports = grammar({
     input_item_list: $ => prec.right(commaSep1($._expression)),
 
     output_item_list: $ => prec.right(commaSep1($._expression)),
+
+    // Obsolescent feature
+    statement_function: $ => prec.right(seq(
+      $.identifier,
+      alias($._statement_function_arg_list, $.argument_list),
+      '=',
+      $._expression,
+    )),
+
+    _statement_function_arg_list: $ => seq('(', commaSep1($.identifier), ')'),
 
     // Expressions
 

--- a/grammar.js
+++ b/grammar.js
@@ -100,7 +100,6 @@ module.exports = grammar({
     [$.elseif_clause, $.identifier],
     [$.elseif_clause],
     [$.elsewhere_clause],
-    [$.interface_statement],
     [$.intrinsic_type],
     [$._intrinsic_type, $.identifier],
     [$.module_statement, $.procedure_qualifier],
@@ -351,6 +350,7 @@ module.exports = grammar({
       optional($.abstract_specifier),
       caseInsensitive('interface'),
       optional(choice($._name, $._generic_procedure)),
+      $._end_of_statement,
     ),
 
     end_interface_statement: $ => prec.right(seq(
@@ -705,6 +705,7 @@ module.exports = grammar({
         $.method_name,
         seq($.binding_name, '=>', $.method_name),
       )),
+      $._end_of_statement,
     ),
 
     binding_name: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -955,6 +955,7 @@ module.exports = grammar({
       $.select_rank_statement,
       $.do_loop_statement,
       $.do_label_statement,
+      $.end_do_label_statement,
       $.format_statement,
       $.open_statement,
       $.close_statement,
@@ -1081,7 +1082,14 @@ module.exports = grammar({
       $.end_do_loop_statement
     ),
 
-    // Deleted feature
+    end_do_loop_statement: $ => seq(
+      whiteSpacedKeyword('end', 'do'),
+      optional($._block_label)
+    ),
+
+    // Deleted feature: non-block `do`. Actually, labelled-do is still
+    // valid (but obsolescent), but we need to capture them separately
+    // because otherwise it's too had to capture them at all
     do_label_statement: $ => seq(
       caseInsensitive('do'),
       $.statement_label_reference,
@@ -1089,10 +1097,13 @@ module.exports = grammar({
       $.loop_control_expression
     ),
 
-    end_do_loop_statement: $ => seq(
+    // Because we've lumped together labelled-do and non-block-do in
+    // `do_label_statement`, we also need to be able to capture `end
+    // do` for a labelled-do
+    end_do_label_statement: $ => prec(-1, seq(
+      $.statement_label,
       whiteSpacedKeyword('end', 'do'),
-      optional($._block_label)
-    ),
+    )),
 
     while_statement: $ => seq(caseInsensitive('while'),
       $.parenthesized_expression),

--- a/grammar.js
+++ b/grammar.js
@@ -757,11 +757,11 @@ module.exports = grammar({
 
     variable_modification: $ => seq(
       repeat1(choice(
-        $.type_qualifier,
+        alias($._standalone_type_qualifier, $.type_qualifier),
         $.variable_attributes
       )),
       optional('::'),
-      $._declaration_targets
+      commaSep1(field('declarator', $._variable_declarator)),
     ),
 
     variable_attributes: $ => seq(
@@ -853,7 +853,7 @@ module.exports = grammar({
       optional(seq('(', '*', ')'))
     ),
 
-    type_qualifier: $ => choice(
+    _standalone_type_qualifier: $ => choice(
       caseInsensitive('abstract'),
       caseInsensitive('allocatable'),
       caseInsensitive('automatic'),
@@ -876,9 +876,6 @@ module.exports = grammar({
         ')'
       ),
       caseInsensitive('intrinsic'),
-      // Next two technically only valid on derived type components
-      field('type_param', caseInsensitive('kind')),
-      field('type_param', caseInsensitive('len')),
       caseInsensitive('managed'),
       caseInsensitive('optional'),
       caseInsensitive('parameter'),
@@ -895,6 +892,16 @@ module.exports = grammar({
       caseInsensitive('texture'),
       caseInsensitive('value'),
       caseInsensitive('volatile')
+    ),
+
+    // These are split out to avoid clash with assignment statements
+    // as it turns out `len` is more likely to be used as a variable
+    // name than any of the other qualifiers
+    type_qualifier: $ => choice(
+      $._standalone_type_qualifier,
+      // Next two technically only valid on derived type components
+      field('type_param', caseInsensitive('kind')),
+      field('type_param', caseInsensitive('len')),
     ),
 
     procedure_qualifier: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -602,7 +602,7 @@ module.exports = grammar({
       caseInsensitive('common'),
       repeat1(choice(
         $.variable_group,
-        commaSep1($.identifier)
+        commaSep1($._variable_declarator)
       ))
     ),
 
@@ -610,7 +610,7 @@ module.exports = grammar({
       '/',
       $._name,
       '/',
-      commaSep1($.identifier)
+      commaSep1($._variable_declarator)
     ),
 
     implicit_range: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -469,6 +469,7 @@ module.exports = grammar({
       $.function,
       $.module_procedure,
       $.subroutine,
+      $.include_statement,
       alias($.preproc_if_in_internal_procedures, $.preproc_if),
       alias($.preproc_ifdef_in_internal_procedures, $.preproc_ifdef),
       $.preproc_include,

--- a/grammar.js
+++ b/grammar.js
@@ -485,8 +485,8 @@ module.exports = grammar({
       seq($.implicit_statement, $._end_of_statement),
       seq($.save_statement, $._end_of_statement),
       seq($.import_statement, $._end_of_statement),
-      seq($.public_statement, $._end_of_statement),
-      seq($.private_statement, $._end_of_statement),
+      $.public_statement,
+      $.private_statement,
       $.enum,
       $.interface,
       $.derived_type_definition,
@@ -574,20 +574,22 @@ module.exports = grammar({
       ))
     )),
 
-    private_statement: $ => prec(1, seq(
+    private_statement: $ => prec.right(1, seq(
       caseInsensitive('private'),
       optional(seq(
-        '::',
+        optional('::'),
         commaSep1(choice($.identifier, $._generic_procedure))
-      ))
+      )),
+      $._end_of_statement,
     )),
 
-    public_statement: $ => prec(1, seq(
+    public_statement: $ => prec.right(1, seq(
       caseInsensitive('public'),
       optional(seq(
-        '::',
+        optional('::'),
         commaSep1(choice($.identifier, $._generic_procedure))
-      ))
+      )),
+      $._end_of_statement,
     )),
 
     namelist_statement: $ => seq(

--- a/package.json
+++ b/package.json
@@ -58,11 +58,10 @@
     {
       "scope": "source.fortran",
       "file-types": [
-        "F90",
         "f90",
-        "f",
-        "f77",
-        "f95"
+        "F90",
+        "f95",
+        "F95"
       ],
       "highlights": [
         "queries/highlights.scm"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4808,6 +4808,10 @@
               "type": "BLANK"
             }
           ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_of_statement"
         }
       ]
     },
@@ -7869,6 +7873,10 @@
               }
             }
           ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_of_statement"
         }
       ]
     },
@@ -15733,9 +15741,6 @@
     ],
     [
       "elsewhere_clause"
-    ],
-    [
-      "interface_statement"
     ],
     [
       "intrinsic_type"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8278,8 +8278,13 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "type_qualifier"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_standalone_type_qualifier"
+                },
+                "named": true,
+                "value": "type_qualifier"
               },
               {
                 "type": "SYMBOL",
@@ -8301,8 +8306,37 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_declaration_targets"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "declarator",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_variable_declarator"
+              }
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "declarator",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_variable_declarator"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -8898,7 +8932,7 @@
         }
       ]
     },
-    "type_qualifier": {
+    "_standalone_type_qualifier": {
       "type": "CHOICE",
       "members": [
         {
@@ -9076,32 +9110,6 @@
           "value": "intrinsic"
         },
         {
-          "type": "FIELD",
-          "name": "type_param",
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "PATTERN",
-              "value": "[kK][iI][nN][dD]"
-            },
-            "named": false,
-            "value": "kind"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "type_param",
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "PATTERN",
-              "value": "[lL][eE][nN]"
-            },
-            "named": false,
-            "value": "len"
-          }
-        },
-        {
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
@@ -9244,6 +9252,41 @@
           },
           "named": false,
           "value": "volatile"
+        }
+      ]
+    },
+    "type_qualifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_standalone_type_qualifier"
+        },
+        {
+          "type": "FIELD",
+          "name": "type_param",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "[kK][iI][nN][dD]"
+            },
+            "named": false,
+            "value": "kind"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "type_param",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "[lL][eE][nN]"
+            },
+            "named": false,
+            "value": "len"
+          }
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9575,6 +9575,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "end_do_label_statement"
+        },
+        {
+          "type": "SYMBOL",
           "name": "format_statement"
         },
         {
@@ -10439,40 +10443,6 @@
         }
       ]
     },
-    "do_label_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[dD][oO]"
-          },
-          "named": false,
-          "value": "do"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "statement_label_reference"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "loop_control_expression"
-        }
-      ]
-    },
     "end_do_loop_statement": {
       "type": "SEQ",
       "members": [
@@ -10516,6 +10486,80 @@
           ]
         }
       ]
+    },
+    "do_label_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[dD][oO]"
+          },
+          "named": false,
+          "value": "do"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "statement_label_reference"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "loop_control_expression"
+        }
+      ]
+    },
+    "end_do_label_statement": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "statement_label"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "PATTERN",
+                      "value": "[eE][nN][dD]"
+                    },
+                    {
+                      "type": "PATTERN",
+                      "value": "[dD][oO]"
+                    }
+                  ]
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "[eE][nN][dD][dD][oO]"
+                }
+              ]
+            },
+            "named": false,
+            "value": "enddo"
+          }
+        ]
+      }
     },
     "while_statement": {
       "type": "SEQ",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5983,6 +5983,10 @@
           "name": "subroutine"
         },
         {
+          "type": "SYMBOL",
+          "name": "include_statement"
+        },
+        {
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6094,30 +6094,12 @@
             ]
           },
           {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "public_statement"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_end_of_statement"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "public_statement"
           },
           {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "private_statement"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_end_of_statement"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "private_statement"
           },
           {
             "type": "SYMBOL",
@@ -6844,7 +6826,7 @@
       }
     },
     "private_statement": {
-      "type": "PREC",
+      "type": "PREC_RIGHT",
       "value": 1,
       "content": {
         "type": "SEQ",
@@ -6865,8 +6847,16 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "STRING",
-                    "value": "::"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "::"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
                   },
                   {
                     "type": "SEQ",
@@ -6917,12 +6907,16 @@
                 "type": "BLANK"
               }
             ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_end_of_statement"
           }
         ]
       }
     },
     "public_statement": {
-      "type": "PREC",
+      "type": "PREC_RIGHT",
       "value": 1,
       "content": {
         "type": "SEQ",
@@ -6943,8 +6937,16 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "STRING",
-                    "value": "::"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "::"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
                   },
                   {
                     "type": "SEQ",
@@ -6995,6 +6997,10 @@
                 "type": "BLANK"
               }
             ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_end_of_statement"
           }
         ]
       }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7056,7 +7056,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "identifier"
+                    "name": "_variable_declarator"
                   },
                   {
                     "type": "REPEAT",
@@ -7069,7 +7069,7 @@
                         },
                         {
                           "type": "SYMBOL",
-                          "name": "identifier"
+                          "name": "_variable_declarator"
                         }
                       ]
                     }
@@ -7101,7 +7101,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_variable_declarator"
             },
             {
               "type": "REPEAT",
@@ -7114,7 +7114,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "identifier"
+                    "name": "_variable_declarator"
                   }
                 ]
               }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6219,6 +6219,19 @@
             ]
           },
           {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "statement_function"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_end_of_statement"
+              }
+            ]
+          },
+          {
             "type": "PREC",
             "value": 1,
             "content": {
@@ -13605,6 +13618,74 @@
         ]
       }
     },
+    "statement_function": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_statement_function_arg_list"
+            },
+            "named": true,
+            "value": "argument_list"
+          },
+          {
+            "type": "STRING",
+            "value": "="
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        ]
+      }
+    },
+    "_statement_function_arg_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
     "_expression": {
       "type": "CHOICE",
       "members": [
@@ -15644,6 +15725,10 @@
     [
       "preproc_else_in_specification_part",
       "program"
+    ],
+    [
+      "statement_function",
+      "_expression"
     ]
   ],
   "precedences": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -425,6 +425,10 @@
           "named": true
         },
         {
+          "type": "end_do_label_statement",
+          "named": true
+        },
+        {
           "type": "file_position_statement",
           "named": true
         },
@@ -878,6 +882,10 @@
           "named": true
         },
         {
+          "type": "end_do_label_statement",
+          "named": true
+        },
+        {
           "type": "enum",
           "named": true
         },
@@ -1204,6 +1212,10 @@
         },
         {
           "type": "do_loop_statement",
+          "named": true
+        },
+        {
+          "type": "end_do_label_statement",
           "named": true
         },
         {
@@ -2565,6 +2577,10 @@
           "named": true
         },
         {
+          "type": "end_do_label_statement",
+          "named": true
+        },
+        {
           "type": "end_do_loop_statement",
           "named": true
         },
@@ -2716,6 +2732,10 @@
           "named": true
         },
         {
+          "type": "end_do_label_statement",
+          "named": true
+        },
+        {
           "type": "file_position_statement",
           "named": true
         },
@@ -2852,6 +2872,10 @@
         },
         {
           "type": "do_loop_statement",
+          "named": true
+        },
+        {
+          "type": "end_do_label_statement",
           "named": true
         },
         {
@@ -2998,6 +3022,10 @@
           "named": true
         },
         {
+          "type": "end_do_label_statement",
+          "named": true
+        },
+        {
           "type": "file_position_statement",
           "named": true
         },
@@ -3121,6 +3149,21 @@
       "types": [
         {
           "type": "block_label",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "end_do_label_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "statement_label",
           "named": true
         }
       ]
@@ -3596,6 +3639,10 @@
           "named": true
         },
         {
+          "type": "end_do_label_statement",
+          "named": true
+        },
+        {
           "type": "end_forall_statement",
           "named": true
         },
@@ -3814,6 +3861,10 @@
         },
         {
           "type": "do_loop_statement",
+          "named": true
+        },
+        {
+          "type": "end_do_label_statement",
           "named": true
         },
         {
@@ -4132,6 +4183,10 @@
         },
         {
           "type": "elseif_clause",
+          "named": true
+        },
+        {
+          "type": "end_do_label_statement",
           "named": true
         },
         {
@@ -5709,6 +5764,10 @@
           "named": true
         },
         {
+          "type": "end_do_label_statement",
+          "named": true
+        },
+        {
           "type": "end_module_procedure_statement",
           "named": true
         },
@@ -6616,6 +6675,10 @@
           "named": true
         },
         {
+          "type": "end_do_label_statement",
+          "named": true
+        },
+        {
           "type": "enum",
           "named": true
         },
@@ -6884,6 +6947,10 @@
           "named": true
         },
         {
+          "type": "end_do_label_statement",
+          "named": true
+        },
+        {
           "type": "enum",
           "named": true
         },
@@ -7120,6 +7187,10 @@
         },
         {
           "type": "do_loop_statement",
+          "named": true
+        },
+        {
+          "type": "end_do_label_statement",
           "named": true
         },
         {
@@ -7455,6 +7526,10 @@
           "named": true
         },
         {
+          "type": "end_do_label_statement",
+          "named": true
+        },
+        {
           "type": "enum",
           "named": true
         },
@@ -7720,6 +7795,10 @@
         },
         {
           "type": "do_loop_statement",
+          "named": true
+        },
+        {
+          "type": "end_do_label_statement",
           "named": true
         },
         {
@@ -8127,6 +8206,10 @@
           "named": true
         },
         {
+          "type": "end_do_label_statement",
+          "named": true
+        },
+        {
           "type": "end_program_statement",
           "named": true
         },
@@ -8385,6 +8468,10 @@
         },
         {
           "type": "do_loop_statement",
+          "named": true
+        },
+        {
+          "type": "end_do_label_statement",
           "named": true
         },
         {
@@ -9323,6 +9410,10 @@
           "named": true
         },
         {
+          "type": "end_do_label_statement",
+          "named": true
+        },
+        {
           "type": "end_subroutine_statement",
           "named": true
         },
@@ -9910,6 +10001,10 @@
           "named": true
         },
         {
+          "type": "end_do_label_statement",
+          "named": true
+        },
+        {
           "type": "file_position_statement",
           "named": true
         },
@@ -10369,6 +10464,10 @@
         },
         {
           "type": "elsewhere_clause",
+          "named": true
+        },
+        {
+          "type": "end_do_label_statement",
           "named": true
         },
         {
@@ -11162,11 +11261,11 @@
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4744,6 +4744,10 @@
           "named": true
         },
         {
+          "type": "include_statement",
+          "named": true
+        },
+        {
           "type": "module_procedure",
           "named": true
         },
@@ -11380,11 +11384,11 @@
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -998,6 +998,10 @@
           "named": true
         },
         {
+          "type": "statement_function",
+          "named": true
+        },
+        {
           "type": "statement_label",
           "named": true
         },
@@ -4000,6 +4004,10 @@
           "named": true
         },
         {
+          "type": "statement_function",
+          "named": true
+        },
+        {
           "type": "statement_label",
           "named": true
         },
@@ -5678,6 +5686,10 @@
           "named": true
         },
         {
+          "type": "statement_function",
+          "named": true
+        },
+        {
           "type": "statement_label",
           "named": true
         },
@@ -5897,6 +5909,10 @@
         },
         {
           "type": "select_type_statement",
+          "named": true
+        },
+        {
+          "type": "statement_function",
           "named": true
         },
         {
@@ -6823,6 +6839,10 @@
           "named": true
         },
         {
+          "type": "statement_function",
+          "named": true
+        },
+        {
           "type": "statement_label",
           "named": true
         },
@@ -7095,6 +7115,10 @@
           "named": true
         },
         {
+          "type": "statement_function",
+          "named": true
+        },
+        {
           "type": "statement_label",
           "named": true
         },
@@ -7335,6 +7359,10 @@
         },
         {
           "type": "select_type_statement",
+          "named": true
+        },
+        {
+          "type": "statement_function",
           "named": true
         },
         {
@@ -7674,6 +7702,10 @@
           "named": true
         },
         {
+          "type": "statement_function",
+          "named": true
+        },
+        {
           "type": "statement_label",
           "named": true
         },
@@ -7943,6 +7975,10 @@
         },
         {
           "type": "select_type_statement",
+          "named": true
+        },
+        {
+          "type": "statement_function",
           "named": true
         },
         {
@@ -8339,6 +8375,10 @@
         },
         {
           "type": "select_type_statement",
+          "named": true
+        },
+        {
+          "type": "statement_function",
           "named": true
         },
         {
@@ -9098,6 +9138,85 @@
     }
   },
   {
+    "type": "statement_function",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        },
+        {
+          "type": "array_literal",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "complex_literal",
+          "named": true
+        },
+        {
+          "type": "concatenation_expression",
+          "named": true
+        },
+        {
+          "type": "derived_type_member_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "implied_do_loop_expression",
+          "named": true
+        },
+        {
+          "type": "logical_expression",
+          "named": true
+        },
+        {
+          "type": "math_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
+          "named": true
+        },
+        {
+          "type": "number_literal",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "relational_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "statement_label",
     "named": true,
     "fields": {}
@@ -9296,6 +9415,10 @@
         },
         {
           "type": "save_statement",
+          "named": true
+        },
+        {
+          "type": "statement_function",
           "named": true
         },
         {
@@ -9539,6 +9662,10 @@
         },
         {
           "type": "select_type_statement",
+          "named": true
+        },
+        {
+          "type": "statement_function",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1433,6 +1433,10 @@
           "named": true
         },
         {
+          "type": "sized_declarator",
+          "named": true
+        },
+        {
           "type": "variable_group",
           "named": true
         }
@@ -10503,6 +10507,10 @@
         {
           "type": "name",
           "named": true
+        },
+        {
+          "type": "sized_declarator",
+          "named": true
         }
       ]
     }
@@ -11384,11 +11392,11 @@
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -10516,14 +10516,6 @@
             "named": true
           },
           {
-            "type": "init_declarator",
-            "named": true
-          },
-          {
-            "type": "pointer_init_declarator",
-            "named": true
-          },
-          {
             "type": "sized_declarator",
             "named": true
           }
@@ -11388,11 +11380,11 @@
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "nopass",

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -422,7 +422,7 @@ Use Operator and Assignment
 module test
   use other, only: operator(==), assignment(=)
   public :: assignment(=)
-  private :: operator(==)
+  private operator(==)
 end module
 
 --------------------------------------------------------------------------------

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -400,6 +400,22 @@ end interface assignment (=)
       (assignment))))
 
 ================================================================================
+Semicolon in interface
+================================================================================
+
+interface operator(+) ; module procedure test_plus ; end interface
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (interface
+    (interface_statement
+      (operator))
+    (procedure_statement
+      (method_name))
+    (end_interface_statement)))
+
+================================================================================
 Use Operator and Assignment
 ================================================================================
 

--- a/test/corpus/regressions.txt
+++ b/test/corpus/regressions.txt
@@ -130,3 +130,27 @@ end program
           (boolean_literal)))
       (end_if_statement))
     (end_program_statement)))
+
+================================================================================
+Assignment/Variable modification clash
+================================================================================
+
+program test
+  integer :: len
+  len = 5
+end program test
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (program
+    (program_statement
+      (name))
+    (variable_declaration
+      (intrinsic_type)
+      (identifier))
+    (assignment_statement
+      (identifier)
+      (number_literal))
+    (end_program_statement
+      (name))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -769,6 +769,10 @@ program test
     do 10, j = 1, 10
       foo(i, j) = i * j
 10 continue
+
+  do 10 i = 1, 10
+    bar(i) = i
+10 end do
 end program test
 
 --------------------------------------------------------------------------------
@@ -800,6 +804,20 @@ end program test
         (identifier)))
     (statement_label)
     (keyword_statement)
+    (do_label_statement
+      (statement_label_reference)
+      (loop_control_expression
+        (identifier)
+        (number_literal)
+        (number_literal)))
+    (assignment_statement
+      (call_expression
+        (identifier)
+        (argument_list
+          (identifier)))
+      (identifier))
+    (end_do_label_statement
+      (statement_label))
     (end_program_statement
       (name))))
 

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -6,6 +6,8 @@ PROGRAM TEST
   INCLUDE 'fftw.f03'
   a = 1.0
   INCLUDE 'debug_point.f03'
+contains
+  include 'functions.f03'
 END PROGRAM
 
 --------------------------------------------------------------------------------
@@ -21,6 +23,10 @@ END PROGRAM
       (number_literal))
     (include_statement
       (filename))
+    (internal_procedures
+      (contains_statement)
+      (include_statement
+        (filename)))
     (end_program_statement)))
 
 ================================================================================

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -2506,3 +2506,77 @@ end
       (statement_label_reference)
       (statement_label_reference))
     (end_program_statement)))
+
+================================================================================
+Statement Functions (Obsolescent)
+================================================================================
+
+      SUBROUTINE CEBCHVXX( THRESH, PATH )      
+      COMPLEX            ZDUM
+!     .. Statement Functions ..
+      REAL               CABS1
+!     ..
+!     .. Statement Function Definitions ..
+      CABS1( ZDUM ) = ABS( REAL( ZDUM ) ) + ABS( AIMAG( ZDUM ) )
+
+!     .. Parameters ..
+      INTEGER            NWISE_I, CWISE_I
+      PARAMETER          (NWISE_I = 1, CWISE_I = 1)
+
+      FACT = 'E'
+      END SUBROUTINE CEBCHVXX
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (subroutine
+    (subroutine_statement
+      (name)
+      (parameters
+        (identifier)
+        (identifier)))
+    (variable_declaration
+      (intrinsic_type)
+      (identifier))
+    (comment)
+    (variable_declaration
+      (intrinsic_type)
+      (identifier))
+    (comment)
+    (comment)
+    (statement_function
+      (identifier)
+      (argument_list
+        (identifier))
+      (math_expression
+        (call_expression
+          (identifier)
+          (argument_list
+            (call_expression
+              (identifier)
+              (argument_list
+                (identifier)))))
+        (call_expression
+          (identifier)
+          (argument_list
+            (call_expression
+              (identifier)
+              (argument_list
+                (identifier)))))))
+    (comment)
+    (variable_declaration
+      (intrinsic_type)
+      (identifier)
+      (identifier))
+    (parameter_statement
+      (parameter_assignment
+        (identifier)
+        (number_literal))
+      (parameter_assignment
+        (identifier)
+        (number_literal)))
+    (assignment_statement
+      (identifier)
+      (string_literal))
+    (end_subroutine_statement
+      (name))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1724,6 +1724,7 @@ Common Statement
 
 PROGRAM TEST
   COMMON /blk1/ m, n /blk2/ o
+  COMMON /blk3/ a(1), b(2, 3)
   COMMON p
 END PROGRAM
 
@@ -1741,6 +1742,18 @@ END PROGRAM
       (variable_group
         (name)
         (identifier)))
+    (common_statement
+      (variable_group
+        (name)
+        (sized_declarator
+          (identifier)
+          (size
+            (number_literal)))
+        (sized_declarator
+          (identifier)
+          (size
+            (number_literal)
+            (number_literal)))))
     (common_statement
       (identifier))
     (end_program_statement)))


### PR DESCRIPTION
Several more features and edge cases required to get good F77/fixed-form compatibility. Main two are:

- array-spec in common blocks: `COMMON /block/ V(10)`
- capturing `end do` when used with label-do blocks: `do 100 i = 1, 10`

With this PR, we can now parse 99.70% of >7000 `.f90` files from about 60 projects.

@stadelmanma After merging this, please could you make a new release? Then I can update the fixed-form grammar