### PR TITLE
Fix scanner using symbol not available to wasm parsers

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -127,10 +127,10 @@ static bool scan_boz(TSLexer *lexer) {
     if (lexer->lookahead == '\'' || lexer->lookahead == '"') {
         quote = lexer->lookahead;
         advance(lexer);
-        if (!isxdigit(lexer->lookahead)) {
+        if (!iswxdigit(lexer->lookahead)) {
             return false;
         }
-        while (isxdigit(lexer->lookahead)) {
+        while (iswxdigit(lexer->lookahead)) {
             advance(lexer); // store all hex digits
         }
         if (lexer->lookahead != quote) {


### PR DESCRIPTION
This prevents use of `tree-sitter playground` which requires wasm build