### PR TITLE
Parse type specifier in `allocate` statements

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1827,7 +1827,7 @@ module.exports = grammar({
         field(
           'kind',
           choice(
-            alias(token.immediate(/[a-zA-Z]\w+/), $.identifier),
+            alias(token.immediate(/[a-zA-Z]\w*/), $.identifier),
             alias(token.immediate(/\d+/), $.number_literal)
           )
         )

--- a/grammar.js
+++ b/grammar.js
@@ -980,6 +980,7 @@ module.exports = grammar({
       $.block_construct,
       $.associate_statement,
       $.file_position_statement,
+      $.allocate_statement,
       $.entry_statement,
     ),
 
@@ -1584,6 +1585,30 @@ module.exports = grammar({
     input_item_list: $ => prec.right(commaSep1($._expression)),
 
     output_item_list: $ => prec.right(commaSep1($._expression)),
+
+    allocate_statement: $ => seq(
+      caseInsensitive('allocate'),
+      '(',
+      optional(field('type', seq(
+        choice(
+          $.intrinsic_type,
+          $.identifier,
+        ),
+        '::'
+      ))),
+      commaSep1(field('allocation', choice(
+        $.identifier,
+        $.derived_type_member_expression,
+        $.sized_allocation,
+      ))),
+      optional(seq(',', commaSep1($.keyword_argument))),
+      ')',
+    ),
+
+    sized_allocation: $ => seq(
+      $._expression,
+      alias($.argument_list, $.size),
+    ),
 
     // Obsolescent feature
     statement_function: $ => prec.right(seq(

--- a/grammar.js
+++ b/grammar.js
@@ -980,6 +980,7 @@ module.exports = grammar({
       $.block_construct,
       $.associate_statement,
       $.file_position_statement,
+      $.entry_statement,
     ),
 
     statement_label: $ => prec(1, alias($._integer_literal, 'statement_label')),
@@ -1593,6 +1594,17 @@ module.exports = grammar({
     )),
 
     _statement_function_arg_list: $ => seq('(', commaSep1($.identifier), ')'),
+
+    // Obsolescent feature
+    entry_statement: $ => seq(
+      caseInsensitive('entry'),
+      field('name', $._name),
+      optional(field('parameters',$._parameters)),
+      optional(repeat(choice(
+        $.language_binding,
+        $.function_result
+      ))),
+    ),
 
     // Expressions
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -15391,7 +15391,7 @@
                   "type": "IMMEDIATE_TOKEN",
                   "content": {
                     "type": "PATTERN",
-                    "value": "[a-zA-Z]\\w+"
+                    "value": "[a-zA-Z]\\w*"
                   }
                 },
                 "named": true,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9694,6 +9694,10 @@
         {
           "type": "SYMBOL",
           "name": "file_position_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "entry_statement"
         }
       ]
     },
@@ -13744,6 +13748,68 @@
         {
           "type": "STRING",
           "value": ")"
+        }
+      ]
+    },
+    "entry_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][tT][rR][yY]"
+          },
+          "named": false,
+          "value": "entry"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_name"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "parameters",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_parameters"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "language_binding"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "function_result"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9697,6 +9697,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "allocate_statement"
+        },
+        {
+          "type": "SYMBOL",
           "name": "entry_statement"
         }
       ]
@@ -13682,6 +13686,181 @@
           }
         ]
       }
+    },
+    "allocate_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[aA][lL][lL][oO][cC][aA][tT][eE]"
+          },
+          "named": false,
+          "value": "allocate"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "type",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "intrinsic_type"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "::"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "allocation",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "derived_type_member_expression"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "sized_allocation"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "allocation",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "identifier"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "derived_type_member_expression"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "sized_allocation"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "keyword_argument"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "keyword_argument"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "sized_allocation": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "argument_list"
+          },
+          "named": true,
+          "value": "size"
+        }
+      ]
     },
     "statement_function": {
       "type": "PREC_RIGHT",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -10,6 +10,58 @@
     "fields": {}
   },
   {
+    "type": "allocate_statement",
+    "named": true,
+    "fields": {
+      "allocation": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "derived_type_member_expression",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "sized_allocation",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "::",
+            "named": false
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "intrinsic_type",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "keyword_argument",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "argument_list",
     "named": true,
     "fields": {},
@@ -380,6 +432,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "allocate_statement",
+          "named": true
+        },
         {
           "type": "arithmetic_if_statement",
           "named": true
@@ -834,6 +890,10 @@
       "required": true,
       "types": [
         {
+          "type": "allocate_statement",
+          "named": true
+        },
+        {
           "type": "arithmetic_if_statement",
           "named": true
         },
@@ -1182,6 +1242,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "allocate_statement",
+          "named": true
+        },
         {
           "type": "arithmetic_if_statement",
           "named": true
@@ -2557,6 +2621,10 @@
       "required": true,
       "types": [
         {
+          "type": "allocate_statement",
+          "named": true
+        },
+        {
           "type": "arithmetic_if_statement",
           "named": true
         },
@@ -2720,6 +2788,10 @@
       "required": false,
       "types": [
         {
+          "type": "allocate_statement",
+          "named": true
+        },
+        {
           "type": "arithmetic_if_statement",
           "named": true
         },
@@ -2866,6 +2938,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "allocate_statement",
+          "named": true
+        },
         {
           "type": "arithmetic_if_statement",
           "named": true
@@ -3017,6 +3093,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "allocate_statement",
+          "named": true
+        },
         {
           "type": "arithmetic_if_statement",
           "named": true
@@ -3687,6 +3767,10 @@
       "required": true,
       "types": [
         {
+          "type": "allocate_statement",
+          "named": true
+        },
+        {
           "type": "arithmetic_if_statement",
           "named": true
         },
@@ -3907,6 +3991,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "allocate_statement",
+          "named": true
+        },
         {
           "type": "arithmetic_if_statement",
           "named": true
@@ -4233,6 +4321,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "allocate_statement",
+          "named": true
+        },
         {
           "type": "arithmetic_if_statement",
           "named": true
@@ -5828,6 +5920,10 @@
       "required": true,
       "types": [
         {
+          "type": "allocate_statement",
+          "named": true
+        },
+        {
           "type": "arithmetic_if_statement",
           "named": true
         },
@@ -6747,6 +6843,10 @@
       "required": false,
       "types": [
         {
+          "type": "allocate_statement",
+          "named": true
+        },
+        {
           "type": "arithmetic_if_statement",
           "named": true
         },
@@ -7027,6 +7127,10 @@
       "required": false,
       "types": [
         {
+          "type": "allocate_statement",
+          "named": true
+        },
+        {
           "type": "arithmetic_if_statement",
           "named": true
         },
@@ -7277,6 +7381,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "allocate_statement",
+          "named": true
+        },
         {
           "type": "arithmetic_if_statement",
           "named": true
@@ -7622,6 +7730,10 @@
       "required": false,
       "types": [
         {
+          "type": "allocate_statement",
+          "named": true
+        },
+        {
           "type": "arithmetic_if_statement",
           "named": true
         },
@@ -7901,6 +8013,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "allocate_statement",
+          "named": true
+        },
         {
           "type": "arithmetic_if_statement",
           "named": true
@@ -8318,6 +8434,10 @@
       "required": true,
       "types": [
         {
+          "type": "allocate_statement",
+          "named": true
+        },
+        {
           "type": "arithmetic_if_statement",
           "named": true
         },
@@ -8590,6 +8710,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "allocate_statement",
+          "named": true
+        },
         {
           "type": "arithmetic_if_statement",
           "named": true
@@ -9243,6 +9367,85 @@
     }
   },
   {
+    "type": "sized_allocation",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "array_literal",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "complex_literal",
+          "named": true
+        },
+        {
+          "type": "concatenation_expression",
+          "named": true
+        },
+        {
+          "type": "derived_type_member_expression",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "implied_do_loop_expression",
+          "named": true
+        },
+        {
+          "type": "logical_expression",
+          "named": true
+        },
+        {
+          "type": "math_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
+          "named": true
+        },
+        {
+          "type": "number_literal",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "relational_expression",
+          "named": true
+        },
+        {
+          "type": "size",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "sized_declarator",
     "named": true,
     "fields": {},
@@ -9616,6 +9819,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "allocate_statement",
+          "named": true
+        },
         {
           "type": "arithmetic_if_statement",
           "named": true
@@ -10220,6 +10427,10 @@
       "required": false,
       "types": [
         {
+          "type": "allocate_statement",
+          "named": true
+        },
+        {
           "type": "arithmetic_if_statement",
           "named": true
         },
@@ -10686,6 +10897,10 @@
       "required": true,
       "types": [
         {
+          "type": "allocate_statement",
+          "named": true
+        },
+        {
           "type": "arithmetic_if_statement",
           "named": true
         },
@@ -11131,6 +11346,10 @@
     "named": false
   },
   {
+    "type": "allocate",
+    "named": false
+  },
+  {
     "type": "assignment",
     "named": false
   },
@@ -11528,11 +11747,11 @@
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -429,6 +429,10 @@
           "named": true
         },
         {
+          "type": "entry_statement",
+          "named": true
+        },
+        {
           "type": "file_position_statement",
           "named": true
         },
@@ -886,6 +890,10 @@
           "named": true
         },
         {
+          "type": "entry_statement",
+          "named": true
+        },
+        {
           "type": "enum",
           "named": true
         },
@@ -1220,6 +1228,10 @@
         },
         {
           "type": "end_do_label_statement",
+          "named": true
+        },
+        {
+          "type": "entry_statement",
           "named": true
         },
         {
@@ -2593,6 +2605,10 @@
           "named": true
         },
         {
+          "type": "entry_statement",
+          "named": true
+        },
+        {
           "type": "file_position_statement",
           "named": true
         },
@@ -2744,6 +2760,10 @@
           "named": true
         },
         {
+          "type": "entry_statement",
+          "named": true
+        },
+        {
           "type": "file_position_statement",
           "named": true
         },
@@ -2884,6 +2904,10 @@
         },
         {
           "type": "end_do_label_statement",
+          "named": true
+        },
+        {
+          "type": "entry_statement",
           "named": true
         },
         {
@@ -3031,6 +3055,10 @@
         },
         {
           "type": "end_do_label_statement",
+          "named": true
+        },
+        {
+          "type": "entry_statement",
           "named": true
         },
         {
@@ -3390,6 +3418,54 @@
     }
   },
   {
+    "type": "entry_statement",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "name",
+            "named": true
+          }
+        ]
+      },
+      "parameters": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "parameters",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "function_result",
+          "named": true
+        },
+        {
+          "type": "language_binding",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "enum",
     "named": true,
     "fields": {},
@@ -3655,6 +3731,10 @@
           "named": true
         },
         {
+          "type": "entry_statement",
+          "named": true
+        },
+        {
           "type": "file_position_statement",
           "named": true
         },
@@ -3877,6 +3957,10 @@
         },
         {
           "type": "end_function_statement",
+          "named": true
+        },
+        {
+          "type": "entry_statement",
           "named": true
         },
         {
@@ -4203,6 +4287,10 @@
         },
         {
           "type": "end_if_statement",
+          "named": true
+        },
+        {
+          "type": "entry_statement",
           "named": true
         },
         {
@@ -5792,6 +5880,10 @@
           "named": true
         },
         {
+          "type": "entry_statement",
+          "named": true
+        },
+        {
           "type": "enum",
           "named": true
         },
@@ -6703,6 +6795,10 @@
           "named": true
         },
         {
+          "type": "entry_statement",
+          "named": true
+        },
+        {
           "type": "enum",
           "named": true
         },
@@ -6979,6 +7075,10 @@
           "named": true
         },
         {
+          "type": "entry_statement",
+          "named": true
+        },
+        {
           "type": "enum",
           "named": true
         },
@@ -7223,6 +7323,10 @@
         },
         {
           "type": "end_do_label_statement",
+          "named": true
+        },
+        {
+          "type": "entry_statement",
           "named": true
         },
         {
@@ -7566,6 +7670,10 @@
           "named": true
         },
         {
+          "type": "entry_statement",
+          "named": true
+        },
+        {
           "type": "enum",
           "named": true
         },
@@ -7839,6 +7947,10 @@
         },
         {
           "type": "end_do_label_statement",
+          "named": true
+        },
+        {
+          "type": "entry_statement",
           "named": true
         },
         {
@@ -8258,6 +8370,10 @@
           "named": true
         },
         {
+          "type": "entry_statement",
+          "named": true
+        },
+        {
           "type": "enum",
           "named": true
         },
@@ -8520,6 +8636,10 @@
         },
         {
           "type": "end_do_label_statement",
+          "named": true
+        },
+        {
+          "type": "entry_statement",
           "named": true
         },
         {
@@ -9549,6 +9669,10 @@
           "named": true
         },
         {
+          "type": "entry_statement",
+          "named": true
+        },
+        {
           "type": "enum",
           "named": true
         },
@@ -10140,6 +10264,10 @@
           "named": true
         },
         {
+          "type": "entry_statement",
+          "named": true
+        },
+        {
           "type": "file_position_statement",
           "named": true
         },
@@ -10603,6 +10731,10 @@
         },
         {
           "type": "end_where_statement",
+          "named": true
+        },
+        {
+          "type": "entry_statement",
           "named": true
         },
         {
@@ -11224,6 +11356,10 @@
   },
   {
     "type": "endwhere",
+    "named": false
+  },
+  {
+    "type": "entry",
     "named": false
   },
   {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -797,7 +797,7 @@ Call Type-Bound Procedure
 
 program use_type_bound_procedures
   call foo%bar()
-  call foo%bar%quux()
+  call foo(n)%bar%quux()
 end program use_type_bound_procedures
 
 --------------------------------------------------------------------------------
@@ -814,7 +814,10 @@ end program use_type_bound_procedures
     (subroutine_call
       (derived_type_member_expression
         (derived_type_member_expression
-          (identifier)
+          (call_expression
+            (identifier)
+            (argument_list
+              (identifier)))
           (type_member))
         (type_member))
       (argument_list))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -20,6 +20,7 @@ PROGRAM TEST
     dbl_val = 1.23D+4
     dbl_val = 1.23D-4
     dbl_val = 1.23D4
+    dbl_val = 1.23e-4_d
     bin_val = B'1011'
     oct_val = O'0158'
     hex_val = Z'09AF'
@@ -92,6 +93,10 @@ END PROGRAM
     (assignment_statement
       (identifier)
       (number_literal))
+    (assignment_statement
+      (identifier)
+      (number_literal
+        (identifier)))
     (assignment_statement
       (identifier)
       (number_literal))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -2599,3 +2599,52 @@ Statement Functions (Obsolescent)
       (string_literal))
     (end_subroutine_statement
       (name))))
+
+================================================================================
+Entry statement (Obsolescent)
+================================================================================
+
+       SUBROUTINE SUB(A, B, C)
+       INTEGER A, B
+       CHARACTER C*4
+
+       RETURN
+
+       ENTRY SUB2(A, B, C)
+       RETURN
+
+       ENTRY SUB3
+       RETURN
+       END
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (subroutine
+    (subroutine_statement
+      (name)
+      (parameters
+        (identifier)
+        (identifier)
+        (identifier)))
+    (variable_declaration
+      (intrinsic_type)
+      (identifier)
+      (identifier))
+    (variable_declaration
+      (intrinsic_type)
+      (sized_declarator
+        (identifier)
+        (character_length)))
+    (keyword_statement)
+    (entry_statement
+      (name)
+      (parameters
+        (identifier)
+        (identifier)
+        (identifier)))
+    (keyword_statement)
+    (entry_statement
+      (name))
+    (keyword_statement)
+    (end_subroutine_statement)))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -2508,6 +2508,76 @@ end program test
       (name))))
 
 ================================================================================
+Allocate statements
+================================================================================
+
+program test
+    allocate(my_int(1, 2))
+    allocate(integer::foo)
+    allocate(my_type::foo, stat=stat_var)
+    allocate(double precision::foo)
+    allocate(my_type::bar(1), foo, parent%child%grandchild(1, 2), errmsg=msg)
+    allocate(parent(n)%child(x, y))
+end program test
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (program
+    (program_statement
+      (name))
+    (allocate_statement
+      allocation: (sized_allocation
+        (identifier)
+        (size
+          (number_literal)
+          (number_literal))))
+    (allocate_statement
+      type: (intrinsic_type)
+      allocation: (identifier))
+    (allocate_statement
+      type: (identifier)
+      allocation: (identifier)
+      (keyword_argument
+        name: (identifier)
+        value: (identifier)))
+    (allocate_statement
+      type: (intrinsic_type)
+      allocation: (identifier))
+    (allocate_statement
+      type: (identifier)
+      allocation: (sized_allocation
+        (identifier)
+        (size
+          (number_literal)))
+      allocation: (identifier)
+      allocation: (sized_allocation
+        (derived_type_member_expression
+          (derived_type_member_expression
+            (identifier)
+            (type_member))
+          (type_member))
+        (size
+          (number_literal)
+          (number_literal)))
+      (keyword_argument
+        name: (identifier)
+        value: (identifier)))
+    (allocate_statement
+      allocation: (sized_allocation
+        (derived_type_member_expression
+          (call_expression
+            (identifier)
+            (argument_list
+              (identifier)))
+          (type_member))
+        (size
+          (identifier)
+          (identifier))))
+    (end_program_statement
+      (name))))
+
+================================================================================
 Arithmetic If Statement (Deleted)
 ================================================================================
 


### PR DESCRIPTION
Closes https://github.com/stadelmanma/tree-sitter-fortran/issues/108

This is a breaking change in that `allocate` statements now appear as explicit nodes (heads up @pjpbyrne!)

Includes #106 and #105 to avoid merge conflicts