### PR TITLE
chore: Updates for tree-sitter 0.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(tree-sitter-fortran
+        VERSION "0.2.0"
+        DESCRIPTION "Fortran grammar for tree-sitter"
+        HOMEPAGE_URL "https://github.com/stadelmanma/tree-sitter-fortran"
+        LANGUAGES C)
+
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+option(TREE_SITTER_REUSE_ALLOCATOR "Reuse the library allocator" OFF)
+
+set(TREE_SITTER_ABI_VERSION 14 CACHE STRING "Tree-sitter ABI version")
+if(NOT ${TREE_SITTER_ABI_VERSION} MATCHES "^[0-9]+$")
+    unset(TREE_SITTER_ABI_VERSION CACHE)
+    message(FATAL_ERROR "TREE_SITTER_ABI_VERSION must be an integer")
+endif()
+
+find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI")
+
+add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
+                   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
+                   COMMAND "${TREE_SITTER_CLI}" generate src/grammar.json
+                            --abi=${TREE_SITTER_ABI_VERSION}
+                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                   COMMENT "Generating parser.c")
+
+add_library(tree-sitter-fortran src/parser.c)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/scanner.c)
+  target_sources(tree-sitter-fortran PRIVATE src/scanner.c)
+endif()
+target_include_directories(tree-sitter-fortran PRIVATE src)
+
+target_compile_definitions(tree-sitter-fortran PRIVATE
+                           $<$<BOOL:${TREE_SITTER_REUSE_ALLOCATOR}>:TREE_SITTER_REUSE_ALLOCATOR>
+                           $<$<CONFIG:Debug>:TREE_SITTER_DEBUG>)
+
+set_target_properties(tree-sitter-fortran
+                      PROPERTIES
+                      C_STANDARD 11
+                      POSITION_INDEPENDENT_CODE ON
+                      SOVERSION "${TREE_SITTER_ABI_VERSION}.${PROJECT_VERSION_MAJOR}"
+                      DEFINE_SYMBOL "")
+
+configure_file(bindings/c/tree-sitter-fortran.pc.in
+               "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-fortran.pc" @ONLY)
+
+include(GNUInstallDirs)
+
+install(FILES bindings/c/tree-sitter-fortran.h
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tree_sitter")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-fortran.pc"
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig")
+install(TARGETS tree-sitter-fortran
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+
+add_custom_target(ts-test "${TREE_SITTER_CLI}" test
+                  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                  COMMENT "tree-sitter test")

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ tree-sitter-language = "0.1.0"
 cc = "1.0"
 
 [dev-dependencies]
-tree-sitter = "0.23"
+tree-sitter = "0.24"

--- a/package.json
+++ b/package.json
@@ -53,20 +53,5 @@
     "prestart": "tree-sitter build --wasm",
     "start": "tree-sitter playground",
     "test": "node --test bindings/node/*_test.js"
-  },
-  "tree-sitter": [
-    {
-      "scope": "source.fortran",
-      "file-types": [
-        "f90",
-        "F90",
-        "f95",
-        "F95"
-      ],
-      "highlights": [
-        "queries/highlights.scm"
-      ],
-      "injection-regex": "fortran"
-    }
-  ]
+  }
 }

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -26,6 +26,11 @@
         "name": "Matt Stadelman",
         "email": "stadelmanma@gmail.com",
         "url": "https://github.com/stadelmanma"
+      },
+      {
+        "name": "Peter Hill",
+        "email": "peter.hill@york.ac.uk",
+        "url": "https://github.com/ZedThree"
       }
     ],
     "links": {

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,43 @@
+{
+  "grammars": [
+    {
+      "name": "fortran",
+      "camelcase": "Fortran",
+      "scope": "source.fortran",
+      "path": ".",
+      "file-types": [
+        "f90",
+        "F90",
+        "f95",
+        "F95"
+      ],
+      "highlights": [
+        "queries/highlights.scm"
+      ],
+      "injection-regex": "fortran"
+    }
+  ],
+  "metadata": {
+    "version": "0.2.0",
+    "license": "MIT",
+    "description": "Fortran grammar for tree-sitter",
+    "authors": [
+      {
+        "name": "Matt Stadelman",
+        "email": "stadelmanma@gmail.com",
+        "url": "https://github.com/stadelmanma"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/stadelmanma/tree-sitter-fortran"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
Latest `tree-sitter-cli` moves some tree-sitter specific metadata out of `package.json` and adds `CMakeLists.txt`