### PR TITLE
Add parent node for procedure bindings and enumerator initialisation

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -706,7 +706,7 @@ module.exports = grammar({
     ),
 
     procedure_statement: $ => seq(
-      $._procedure_kind,
+      $.procedure_kind,
       optional(seq(
         '(', alias($.identifier, $.procedure_interface), ')'
       )),
@@ -728,7 +728,7 @@ module.exports = grammar({
     ),
     method_name: $ => alias($.identifier, 'method_name'),
 
-    _procedure_kind: $ => choice(
+    procedure_kind: $ => choice(
       caseInsensitive('generic'),
       caseInsensitive('initial'),
       caseInsensitive('procedure'),

--- a/grammar.js
+++ b/grammar.js
@@ -715,13 +715,13 @@ module.exports = grammar({
         commaSep1($.procedure_attribute)
       )),
       optional('::'),
-      commaSep1(choice(
+      commaSep1(field('declarator', choice(
         $.method_name,
-        seq($.binding_name, '=>', $.method_name),
-      )),
+        $.binding_declarator,
+      ))),
       $._end_of_statement,
     ),
-
+    binding_declarator: $ => seq($.binding_name, '=>', $.method_name),
     binding_name: $ => choice(
       $.identifier,
       $._generic_procedure

--- a/grammar.js
+++ b/grammar.js
@@ -717,11 +717,11 @@ module.exports = grammar({
       optional('::'),
       commaSep1(field('declarator', choice(
         $.method_name,
-        $.binding_declarator,
+        $.binding,
       ))),
       $._end_of_statement,
     ),
-    binding_declarator: $ => seq($.binding_name, '=>', $.method_name),
+    binding: $ => seq($.binding_name, '=>', $.method_name),
     binding_name: $ => choice(
       $.identifier,
       $._generic_procedure

--- a/grammar.js
+++ b/grammar.js
@@ -1589,13 +1589,10 @@ module.exports = grammar({
     enumerator_statement: $ => seq(
       caseInsensitive('enumerator'),
       optional('::'),
-      commaSep1(choice(
+      commaSep1(field('declarator', choice(
         $.identifier,
-        seq($.identifier, '=', choice(
-          $.number_literal,
-          $.unary_expression,
-        ))
-      ))
+        alias($._declaration_assignment, $.init_declarator),
+      )))
     ),
 
     end_enum_statement: $ => whiteSpacedKeyword('end', 'enum'),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10662,7 +10662,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_procedure_kind"
+          "name": "procedure_kind"
         },
         {
           "type": "CHOICE",
@@ -10844,7 +10844,7 @@
       "named": false,
       "value": "method_name"
     },
-    "_procedure_kind": {
+    "procedure_kind": {
       "type": "CHOICE",
       "members": [
         {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10763,7 +10763,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "binding_declarator"
+                    "name": "binding"
                   }
                 ]
               }
@@ -10789,7 +10789,7 @@
                         },
                         {
                           "type": "SYMBOL",
-                          "name": "binding_declarator"
+                          "name": "binding"
                         }
                       ]
                     }
@@ -10805,7 +10805,7 @@
         }
       ]
     },
-    "binding_declarator": {
+    "binding": {
       "type": "SEQ",
       "members": [
         {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -16404,39 +16404,26 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
+              "type": "FIELD",
+              "name": "declarator",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
                       "type": "SYMBOL",
-                      "name": "identifier"
+                      "name": "_declaration_assignment"
                     },
-                    {
-                      "type": "STRING",
-                      "value": "="
-                    },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "number_literal"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "unary_expression"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
+                    "named": true,
+                    "value": "init_declarator"
+                  }
+                ]
+              }
             },
             {
               "type": "REPEAT",
@@ -16448,39 +16435,26 @@
                     "value": ","
                   },
                   {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "identifier"
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
+                    "type": "FIELD",
+                    "name": "declarator",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "identifier"
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
                             "type": "SYMBOL",
-                            "name": "identifier"
+                            "name": "_declaration_assignment"
                           },
-                          {
-                            "type": "STRING",
-                            "value": "="
-                          },
-                          {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "number_literal"
-                              },
-                              {
-                                "type": "SYMBOL",
-                                "name": "unary_expression"
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
+                          "named": true,
+                          "value": "init_declarator"
+                        }
+                      ]
+                    }
                   }
                 ]
               }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10752,30 +10752,21 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "method_name"
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "binding_name"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "=>"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "method_name"
-                    }
-                  ]
-                }
-              ]
+              "type": "FIELD",
+              "name": "declarator",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "method_name"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "binding_declarator"
+                  }
+                ]
+              }
             },
             {
               "type": "REPEAT",
@@ -10787,30 +10778,21 @@
                     "value": ","
                   },
                   {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "method_name"
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "binding_name"
-                          },
-                          {
-                            "type": "STRING",
-                            "value": "=>"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "method_name"
-                          }
-                        ]
-                      }
-                    ]
+                    "type": "FIELD",
+                    "name": "declarator",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "method_name"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "binding_declarator"
+                        }
+                      ]
+                    }
                   }
                 ]
               }
@@ -10820,6 +10802,23 @@
         {
           "type": "SYMBOL",
           "name": "_end_of_statement"
+        }
+      ]
+    },
+    "binding_declarator": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "binding_name"
+        },
+        {
+          "type": "STRING",
+          "value": "=>"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "method_name"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -12585,6 +12585,10 @@
               "name": "_end_of_statement"
             }
           ]
+        },
+        {
+          "type": "STRING",
+          "value": ";"
         }
       ]
     },
@@ -20011,9 +20015,18 @@
         ]
       }
     },
-    "_semicolon": {
-      "type": "STRING",
-      "value": ";"
+    "_end_of_statement": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_external_end_of_statement"
+        }
+      ]
     },
     "_newline": {
       "type": "STRING",
@@ -20136,7 +20149,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "_end_of_statement"
+      "name": "_external_end_of_statement"
     },
     {
       "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4615,24 +4615,21 @@
   {
     "type": "enumerator_statement",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "number_literal",
-          "named": true
-        },
-        {
-          "type": "unary_expression",
-          "named": true
-        }
-      ]
+    "fields": {
+      "declarator": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "init_declarator",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -9728,6 +9728,11 @@
     "fields": {}
   },
   {
+    "type": "procedure_kind",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "procedure_qualifier",
     "named": true,
     "fields": {}
@@ -9753,7 +9758,7 @@
     },
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "procedure_attribute",
@@ -9761,6 +9766,10 @@
         },
         {
           "type": "procedure_interface",
+          "named": true
+        },
+        {
+          "type": "procedure_kind",
           "named": true
         }
       ]
@@ -13357,11 +13366,11 @@
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -899,6 +899,25 @@
     }
   },
   {
+    "type": "binding_declarator",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "binding_name",
+          "named": true
+        },
+        {
+          "type": "method_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "binding_name",
     "named": true,
     "fields": {},
@@ -9719,19 +9738,26 @@
   {
     "type": "procedure_statement",
     "named": true,
-    "fields": {},
+    "fields": {
+      "declarator": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "binding_declarator",
+            "named": true
+          },
+          {
+            "type": "method_name",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "binding_name",
-          "named": true
-        },
-        {
-          "type": "method_name",
-          "named": true
-        },
         {
           "type": "procedure_attribute",
           "named": true
@@ -13334,11 +13360,11 @@
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -899,7 +899,7 @@
     }
   },
   {
-    "type": "binding_declarator",
+    "type": "binding",
     "named": true,
     "fields": {},
     "children": {
@@ -9746,7 +9746,7 @@
         "required": true,
         "types": [
           {
-            "type": "binding_declarator",
+            "type": "binding",
             "named": true
           },
           {
@@ -13366,11 +13366,11 @@
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "nopass",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -12757,6 +12757,10 @@
     "named": false
   },
   {
+    "type": ";",
+    "named": false
+  },
+  {
     "type": "<",
     "named": false
   },
@@ -13330,11 +13334,11 @@
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "nopass",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -158,7 +158,7 @@ static bool scan_end_of_statement(Scanner *scanner, TSLexer *lexer) {
     // newline
 
     // Semicolons and EOF always end the statement
-    if (lexer->lookahead == ';' || lexer->eof(lexer)) {
+    if (lexer->eof(lexer)) {
         skip(lexer);
         lexer->result_symbol = END_OF_STATEMENT;
         return true;

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -80,8 +80,10 @@ end module
       (interface_statement
         (name))
       (procedure_statement
+        (procedure_kind)
         (method_name))
       (procedure_statement
+        (procedure_kind)
         (method_name))
       (end_interface_statement))
     (variable_declaration
@@ -325,8 +327,10 @@ end interface
     (interface_statement
       (name))
     (procedure_statement
+      (procedure_kind)
       (method_name))
     (procedure_statement
+      (procedure_kind)
       (method_name))
     (end_interface_statement)))
 
@@ -354,8 +358,10 @@ end interface operator (.not.)
     (interface_statement
       (operator))
     (procedure_statement
+      (procedure_kind)
       (method_name))
     (procedure_statement
+      (procedure_kind)
       (method_name))
     (end_interface_statement
       (operator)))
@@ -363,6 +369,7 @@ end interface operator (.not.)
     (interface_statement
       (operator))
     (procedure_statement
+      (procedure_kind)
       (method_name))
     (function
       (function_statement
@@ -395,6 +402,7 @@ end interface assignment (=)
     (interface_statement
       (assignment))
     (procedure_statement
+      (procedure_kind)
       (method_name))
     (end_interface_statement
       (assignment))))
@@ -412,6 +420,7 @@ interface operator(+) ; module procedure test_plus ; end interface
     (interface_statement
       (operator))
     (procedure_statement
+      (procedure_kind)
       (method_name))
     (end_interface_statement)))
 
@@ -851,19 +860,23 @@ end program
       (derived_type_procedures
         (contains_statement)
         (procedure_statement
+          (procedure_kind)
           (procedure_attribute)
           (procedure_attribute)
           (method_name))
         (comment)
         (procedure_statement
+          (procedure_kind)
           (method_name))
         (comment)
         (procedure_statement
+          (procedure_kind)
           (procedure_attribute)
           (procedure_attribute
             (identifier))
           (method_name))
         (procedure_statement
+          (procedure_kind)
           (procedure_attribute)
           (binding_declarator
             (binding_name
@@ -871,24 +884,28 @@ end program
             (method_name))
           (method_name))
         (procedure_statement
+          (procedure_kind)
           (procedure_attribute)
           (binding_declarator
             (binding_name
               (assignment))
             (method_name)))
         (procedure_statement
+          (procedure_kind)
           (procedure_attribute)
           (binding_declarator
             (binding_name
               (operator))
             (method_name)))
         (procedure_statement
+          (procedure_kind)
           (method_name)
           (binding_declarator
             (binding_name
               (identifier))
             (method_name)))
         (procedure_statement
+          (procedure_kind)
           (method_name)))
       (end_type_statement
         (name)))
@@ -990,6 +1007,7 @@ end program
       (derived_type_procedures
         (contains_statement)
         (procedure_statement
+          (procedure_kind)
           (procedure_interface)
           (procedure_attribute)
           (method_name)))
@@ -1030,8 +1048,10 @@ end program test
         (contains_statement)
         (private_statement)
         (procedure_statement
+          (procedure_kind)
           (method_name))
         (procedure_statement
+          (procedure_kind)
           (procedure_attribute)
           (method_name)))
       (end_type_statement

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -865,25 +865,29 @@ end program
           (method_name))
         (procedure_statement
           (procedure_attribute)
-          (binding_name
-            (identifier))
-          (method_name)
+          (binding_declarator
+            (binding_name
+              (identifier))
+            (method_name))
           (method_name))
         (procedure_statement
           (procedure_attribute)
-          (binding_name
-            (assignment))
-          (method_name))
+          (binding_declarator
+            (binding_name
+              (assignment))
+            (method_name)))
         (procedure_statement
           (procedure_attribute)
-          (binding_name
-            (operator))
-          (method_name))
+          (binding_declarator
+            (binding_name
+              (operator))
+            (method_name)))
         (procedure_statement
           (method_name)
-          (binding_name
-            (identifier))
-          (method_name))
+          (binding_declarator
+            (binding_name
+              (identifier))
+            (method_name)))
         (procedure_statement
           (method_name)))
       (end_type_statement

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -878,7 +878,7 @@ end program
         (procedure_statement
           (procedure_kind)
           (procedure_attribute)
-          (binding_declarator
+          (binding
             (binding_name
               (identifier))
             (method_name))
@@ -886,21 +886,21 @@ end program
         (procedure_statement
           (procedure_kind)
           (procedure_attribute)
-          (binding_declarator
+          (binding
             (binding_name
               (assignment))
             (method_name)))
         (procedure_statement
           (procedure_kind)
           (procedure_attribute)
-          (binding_declarator
+          (binding
             (binding_name
               (operator))
             (method_name)))
         (procedure_statement
           (procedure_kind)
           (method_name)
-          (binding_declarator
+          (binding
             (binding_name
               (identifier))
             (method_name)))

--- a/test/corpus/preprocessor.txt
+++ b/test/corpus/preprocessor.txt
@@ -490,6 +490,7 @@ end module foo
         (preproc_if
           (identifier)
           (procedure_statement
+            (procedure_kind)
             (method_name))))
       (end_type_statement
         (name)))
@@ -762,11 +763,12 @@ end module
       (interface_statement
         (name))
       (procedure_statement
+        (procedure_kind)
         (method_name))
       (preproc_ifdef
         (identifier)
         (procedure_statement
+          (procedure_kind)
           (method_name)))
       (end_interface_statement))
     (end_module_statement)))
-

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1836,20 +1836,22 @@ END PROGRAM test
         (language_binding
           (identifier)))
       (enumerator_statement
-        (identifier)
-        (number_literal))
+        declarator: (init_declarator
+          left: (identifier)
+          right: (number_literal)))
       (enumerator_statement
-        (identifier)
-        (identifier))
+        declarator: (identifier)
+        declarator: (identifier))
       (end_enum_statement))
     (enum
       (enum_statement
         (language_binding
           (identifier)))
       (enumerator_statement
-        (identifier)
-        (unary_expression
-          (number_literal)))
+        declarator: (init_declarator
+          left: (identifier)
+          right: (unary_expression
+            argument: (number_literal))))
       (end_enum_statement))
     (end_program_statement
       (name))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -2278,15 +2278,17 @@ end module
         (comment)
         (procedure_statement
           (procedure_attribute)
-          (binding_name
-            (defined_io_procedure))
-          (method_name))
+          (binding_declarator
+            (binding_name
+              (defined_io_procedure))
+            (method_name)))
         (comment)
         (procedure_statement
           (procedure_attribute)
-          (binding_name
-            (identifier))
-          (method_name)))
+          (binding_declarator
+            (binding_name
+              (identifier))
+            (method_name))))
       (end_type_statement
         (name)))
     (end_module_statement)))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -3012,3 +3012,26 @@ end program test
       (end_coarray_critical_statement))
     (end_program_statement
       (name))))
+
+================================================================================
+Extra semicolon
+================================================================================
+
+program test
+  integer :: foo; ; foo = 1
+end program test
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (program
+    (program_statement
+      (name))
+    (variable_declaration
+      (intrinsic_type)
+      (identifier))
+    (assignment_statement
+      (identifier)
+      (number_literal))
+    (end_program_statement
+      (name))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -2263,12 +2263,14 @@ end module
       (interface_statement
         (defined_io_procedure))
       (procedure_statement
+        (procedure_kind)
         (method_name))
       (end_interface_statement))
     (interface
       (interface_statement
         (defined_io_procedure))
       (procedure_statement
+        (procedure_kind)
         (method_name))
       (end_interface_statement
         (defined_io_procedure)))
@@ -2279,6 +2281,7 @@ end module
         (contains_statement)
         (comment)
         (procedure_statement
+          (procedure_kind)
           (procedure_attribute)
           (binding_declarator
             (binding_name
@@ -2286,6 +2289,7 @@ end module
             (method_name)))
         (comment)
         (procedure_statement
+          (procedure_kind)
           (procedure_attribute)
           (binding_declarator
             (binding_name

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -2283,7 +2283,7 @@ end module
         (procedure_statement
           (procedure_kind)
           (procedure_attribute)
-          (binding_declarator
+          (binding
             (binding_name
               (defined_io_procedure))
             (method_name)))
@@ -2291,7 +2291,7 @@ end module
         (procedure_statement
           (procedure_kind)
           (procedure_attribute)
-          (binding_declarator
+          (binding
             (binding_name
               (identifier))
             (method_name))))


### PR DESCRIPTION
Previously it was hard to iterate over all the methods in a
`procedure_statement` as procedure aliases were at the same level.

This is a similar change to variable declarations, where adding a
new parent node made it easier to iterate over init declarations.

Also making this a field for consistency with variable declarations

(includes #123)