### PR TITLE
Make statement_label_reference node named

### DIFF
--- a/src/node-types.json
+++ b/src/node-types.json
@@ -11032,7 +11032,7 @@
   },
   {
     "type": "statement_label_reference",
-    "named": false,
+    "named": true,
     "fields": {}
   },
   {


### PR DESCRIPTION
Keep it consistent with the rest of the nodes that use it as a named child