### PR TITLE
Allow dollar-sign in identifiers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -2052,7 +2052,7 @@ module.exports = grammar({
     // correctly as either a keyword or a plain identifier, we must
     // add the keywords here -- and possibly in `conflicts` too.
     identifier: $ => choice(
-      /[a-zA-Z_]\w*/,
+      /[a-zA-Z_$][\w$]*/,
       caseInsensitive('allocatable'),
       caseInsensitive('automatic'),
       caseInsensitive('block'),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -19514,7 +19514,7 @@
       "members": [
         {
           "type": "PATTERN",
-          "value": "[a-zA-Z_]\\w*"
+          "value": "[a-zA-Z_$][\\w$]*"
         },
         {
           "type": "ALIAS",

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -3043,3 +3043,26 @@ end program test
       (number_literal))
     (end_program_statement
       (name))))
+
+================================================================================
+Dollar in identifiers (extension)
+================================================================================
+
+program test
+  integer, parameter :: foo$ = 1
+end program test
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (program
+    (program_statement
+      (name))
+    (variable_declaration
+      (intrinsic_type)
+      (type_qualifier)
+      (init_declarator
+        (identifier)
+        (number_literal)))
+    (end_program_statement
+      (name))))


### PR DESCRIPTION
Extension supported by multiple compilers, although with varying restrictions.

Closes #120