### PR TITLE
Fix Hollerith constants inside Format statement

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -60,6 +60,7 @@ module.exports = grammar({
     $._string_literal_kind,
     $._external_end_of_statement,
     $._preproc_unary_operator,
+    $.hollerith_constant,
   ],
 
   extras: $ => [
@@ -1530,7 +1531,6 @@ module.exports = grammar({
 
     // H is not a valid edit descriptor because it clashes with Hollerith constants
     edit_descriptor: $ => /[a-gi-zA-GI-Z0-9/:.*$]+/,
-    hollerith_constant: $ => prec.right(10, /[0-9]+H[^/,)]+/),
 
     _io_arguments: $ => seq(
       '(',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "fortran",
   "rules": {
     "translation_unit": {
@@ -15993,14 +15992,6 @@
       "type": "PATTERN",
       "value": "[a-gi-zA-GI-Z0-9/:.*$]+"
     },
-    "hollerith_constant": {
-      "type": "PREC_RIGHT",
-      "value": 10,
-      "content": {
-        "type": "PATTERN",
-        "value": "[0-9]+H[^/,)]+"
-      }
-    },
     "_io_arguments": {
       "type": "SEQ",
       "members": [
@@ -20581,11 +20572,32 @@
     {
       "type": "SYMBOL",
       "name": "_preproc_unary_operator"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "hollerith_constant"
     }
   ],
   "inline": [
     "_top_level_item",
     "_statement"
   ],
-  "supertypes": []
+  "supertypes": [],
+  "PREC": {
+    "ASSIGNMENT": -10,
+    "DEFAULT": 0,
+    "DEFINED_OPERATOR": 2,
+    "LOGICAL_EQUIV": 5,
+    "LOGICAL_OR": 10,
+    "LOGICAL_AND": 20,
+    "LOGICAL_NOT": 30,
+    "RELATIONAL": 40,
+    "ADDITIVE": 50,
+    "MULTIPLICATIVE": 60,
+    "EXPONENT": 70,
+    "CALL": 80,
+    "UNARY": 90,
+    "TYPE_MEMBER": 100
+  }
 }
+

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5808,11 +5808,6 @@
     }
   },
   {
-    "type": "hollerith_constant",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "identifier",
     "named": true,
     "fields": {}
@@ -12499,7 +12494,6 @@
   {
     "type": "translation_unit",
     "named": true,
-    "root": true,
     "fields": {},
     "children": {
       "multiple": true,
@@ -14058,6 +14052,10 @@
     "named": false
   },
   {
+    "type": "hollerith_constant",
+    "named": true
+  },
+  {
     "type": "host",
     "named": false
   },
@@ -14171,11 +14169,11 @@
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "nopass",

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -14,6 +14,7 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
+#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -278,7 +279,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(default : 4101)
+#pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,8 +13,9 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -47,7 +48,6 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
-  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {
@@ -86,11 +86,6 @@ typedef union {
     bool reusable;
   } entry;
 } TSParseActionEntry;
-
-typedef struct {
-  int32_t start;
-  int32_t end;
-} TSCharacterRange;
 
 struct TSLanguage {
   uint32_t version;
@@ -131,38 +126,13 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
-  uint32_t index = 0;
-  uint32_t size = len - index;
-  while (size > 1) {
-    uint32_t half_size = size / 2;
-    uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
-    if (lookahead >= range->start && lookahead <= range->end) {
-      return true;
-    } else if (lookahead > range->end) {
-      index = mid_index;
-    }
-    size -= half_size;
-  }
-  TSCharacterRange *range = &ranges[index];
-  return (lookahead >= range->start && lookahead <= range->end);
-}
-
 /*
  *  Lexer Macros
  */
 
-#ifdef _MSC_VER
-#define UNUSED __pragma(warning(suppress : 4101))
-#else
-#define UNUSED __attribute__((unused))
-#endif
-
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
-  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -176,17 +146,6 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {                          \
     state = state_value;     \
     goto next_state;         \
-  }
-
-#define ADVANCE_MAP(...)                                              \
-  {                                                                   \
-    static const uint16_t map[] = { __VA_ARGS__ };                    \
-    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
-      if (map[i] == lookahead) {                                      \
-        state = map[i + 1];                                           \
-        goto next_state;                                              \
-      }                                                               \
-    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -207,7 +166,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
 
 #define STATE(id) id
 
@@ -217,7 +176,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value)          \
+      .state = state_value            \
     }                                 \
   }}
 
@@ -225,7 +184,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value),         \
+      .state = state_value,           \
       .repetition = true              \
     }                                 \
   }}
@@ -238,15 +197,14 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }                                 \
   }}
 
-#define REDUCE(symbol_name, children, precedence, prod_id) \
-  {{                                                       \
-    .reduce = {                                            \
-      .type = TSParseActionTypeReduce,                     \
-      .symbol = symbol_name,                               \
-      .child_count = children,                             \
-      .dynamic_precedence = precedence,                    \
-      .production_id = prod_id                             \
-    },                                                     \
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
   }}
 
 #define RECOVER()                    \

--- a/test/corpus/line_continuations.txt
+++ b/test/corpus/line_continuations.txt
@@ -217,3 +217,38 @@ end program
       (output_item_list
         (string_literal)))
     (end_program_statement)))
+
+================================================================================
+Line continuation in hollerith constants
+================================================================================
+program test
+1 format(6x, 10habcdef,&
+    &ghi)
+2 format(6x, 1&
+    &0habcdefghik)
+3 format(6x, 10&
+    &habcdefghik)
+end program
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (program
+    (program_statement
+      (name))
+    (statement_label)
+    (format_statement
+      (transfer_items
+        (edit_descriptor)
+        (hollerith_constant)))
+    (statement_label)
+    (format_statement
+      (transfer_items
+        (edit_descriptor)
+        (hollerith_constant)))
+    (statement_label)
+    (format_statement
+      (transfer_items
+        (edit_descriptor)
+        (hollerith_constant)))
+    (end_program_statement)))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1455,6 +1455,7 @@ PROGRAM TEST
 4 FORMAT(*(G15.8,:,','))
 5 FORMAT(/1X,'NUMBER OF DATA Total/ACCEPTED'/1X,i10/1X)
 6 FORMAT(3(1H-), 2HOK, 10H SOLUTION // 5D15.7)
+7 FORMAT(6x, 10Hv=1, w=x/2)
 END PROGRAM
 
 --------------------------------------------------------------------------------
@@ -1507,6 +1508,11 @@ END PROGRAM
         (hollerith_constant)
         (edit_descriptor)
         (edit_descriptor)))
+    (statement_label)
+    (format_statement
+      (transfer_items
+        (edit_descriptor)
+        (hollerith_constant)))
     (end_program_statement)))
 
 ================================================================================


### PR DESCRIPTION
This implementation tries to parse specifically the `n` characters in the Hollerith Constant instead of assuming some stop characters which can be valid inside the constant.