### PR TITLE
Split the aliasing of `end` statements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2387,18 +2387,6 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
-    "node_modules/tree-sitter": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
-      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "node-addon-api": "^8.3.0",
-        "node-gyp-build": "^4.8.4"
-      }
-    },
     "node_modules/tree-sitter-cli": {
       "version": "0.24.7",
       "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.24.7.tgz",
@@ -2411,16 +2399,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/tree-sitter/node_modules/node-addon-api": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
-      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -2712,8 +2690,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -3101,8 +3078,7 @@
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
       "integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",
@@ -4283,24 +4259,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
-    },
-    "tree-sitter": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
-      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
-      "peer": true,
-      "requires": {
-        "node-addon-api": "^8.3.0",
-        "node-gyp-build": "^4.8.4"
-      },
-      "dependencies": {
-        "node-addon-api": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
-          "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
-          "peer": true
-        }
-      }
     },
     "tree-sitter-cli": {
       "version": "0.24.7",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7229,39 +7229,49 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "ALIAS",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
                       "type": "PATTERN",
                       "value": "[eE][nN][dD]"
                     },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
+                    "named": false,
+                    "value": "end"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "ALIAS",
+                        "content": {
                           "type": "PATTERN",
                           "value": "[pP][rR][oO][gG][rR][aA][mM]"
                         },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
+                        "named": false,
+                        "value": "program"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "ALIAS",
+                "content": {
                   "type": "PATTERN",
                   "value": "[eE][nN][dD][pP][rR][oO][gG][rR][aA][mM]"
-                }
-              ]
-            },
-            "named": false,
-            "value": "endprogram"
+                },
+                "named": false,
+                "value": "endprogram"
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -7366,39 +7376,49 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "ALIAS",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
                       "type": "PATTERN",
                       "value": "[eE][nN][dD]"
                     },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
+                    "named": false,
+                    "value": "end"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "ALIAS",
+                        "content": {
                           "type": "PATTERN",
                           "value": "[mM][oO][dD][uU][lL][eE]"
                         },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
+                        "named": false,
+                        "value": "module"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "ALIAS",
+                "content": {
                   "type": "PATTERN",
                   "value": "[eE][nN][dD][mM][oO][dD][uU][lL][eE]"
-                }
-              ]
-            },
-            "named": false,
-            "value": "endmodule"
+                },
+                "named": false,
+                "value": "endmodule"
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -7544,39 +7564,49 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "ALIAS",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
                       "type": "PATTERN",
                       "value": "[eE][nN][dD]"
                     },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
+                    "named": false,
+                    "value": "end"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "ALIAS",
+                        "content": {
                           "type": "PATTERN",
                           "value": "[sS][uU][bB][mM][oO][dD][uU][lL][eE]"
                         },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
+                        "named": false,
+                        "value": "submodule"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "ALIAS",
+                "content": {
                   "type": "PATTERN",
                   "value": "[eE][nN][dD][sS][uU][bB][mM][oO][dD][uU][lL][eE]"
-                }
-              ]
-            },
-            "named": false,
-            "value": "endsubmodule"
+                },
+                "named": false,
+                "value": "endsubmodule"
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -7747,31 +7777,41 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "ALIAS",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
                       "type": "PATTERN",
                       "value": "[eE][nN][dD]"
                     },
-                    {
+                    "named": false,
+                    "value": "end"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
                       "type": "PATTERN",
                       "value": "[iI][nN][tT][eE][rR][fF][aA][cC][eE]"
-                    }
-                  ]
-                },
-                {
+                    },
+                    "named": false,
+                    "value": "interface"
+                  }
+                ]
+              },
+              {
+                "type": "ALIAS",
+                "content": {
                   "type": "PATTERN",
                   "value": "[eE][nN][dD][iI][nN][tT][eE][rR][fF][aA][cC][eE]"
-                }
-              ]
-            },
-            "named": false,
-            "value": "endinterface"
+                },
+                "named": false,
+                "value": "endinterface"
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -7848,31 +7888,41 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[bB][lL][oO][cC][kK]"
                   },
-                  {
+                  "named": false,
+                  "value": "block"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[dD][aA][tT][aA]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "data"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[bB][lL][oO][cC][kK][dD][aA][tT][aA]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "blockdata"
+              },
+              "named": false,
+              "value": "blockdata"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -8256,39 +8306,49 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "ALIAS",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
                       "type": "PATTERN",
                       "value": "[eE][nN][dD]"
                     },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
+                    "named": false,
+                    "value": "end"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "ALIAS",
+                        "content": {
                           "type": "PATTERN",
                           "value": "[sS][uU][bB][rR][oO][uU][tT][iI][nN][eE]"
                         },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
+                        "named": false,
+                        "value": "subroutine"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "ALIAS",
+                "content": {
                   "type": "PATTERN",
                   "value": "[eE][nN][dD][sS][uU][bB][rR][oO][uU][tT][iI][nN][eE]"
-                }
-              ]
-            },
-            "named": false,
-            "value": "endsubroutine"
+                },
+                "named": false,
+                "value": "endsubroutine"
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -8453,39 +8513,49 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "ALIAS",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
                       "type": "PATTERN",
                       "value": "[eE][nN][dD]"
                     },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
+                    "named": false,
+                    "value": "end"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "ALIAS",
+                        "content": {
                           "type": "PATTERN",
                           "value": "[pP][rR][oO][cC][eE][dD][uU][rR][eE]"
                         },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
+                        "named": false,
+                        "value": "procedure"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "ALIAS",
+                "content": {
                   "type": "PATTERN",
                   "value": "[eE][nN][dD][pP][rR][oO][cC][eE][dD][uU][rR][eE]"
-                }
-              ]
-            },
-            "named": false,
-            "value": "endprocedure"
+                },
+                "named": false,
+                "value": "endprocedure"
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -8884,39 +8954,49 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "ALIAS",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
                       "type": "PATTERN",
                       "value": "[eE][nN][dD]"
                     },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
+                    "named": false,
+                    "value": "end"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "ALIAS",
+                        "content": {
                           "type": "PATTERN",
                           "value": "[fF][uU][nN][cC][tT][iI][oO][nN]"
                         },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
+                        "named": false,
+                        "value": "function"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "ALIAS",
+                "content": {
                   "type": "PATTERN",
                   "value": "[eE][nN][dD][fF][uU][nN][cC][tT][iI][oO][nN]"
-                }
-              ]
-            },
-            "named": false,
-            "value": "endfunction"
+                },
+                "named": false,
+                "value": "endfunction"
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -10736,39 +10816,49 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "ALIAS",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
                       "type": "PATTERN",
                       "value": "[eE][nN][dD]"
                     },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
+                    "named": false,
+                    "value": "end"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "ALIAS",
+                        "content": {
                           "type": "PATTERN",
                           "value": "[tT][yY][pP][eE]"
                         },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
+                        "named": false,
+                        "value": "type"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "ALIAS",
+                "content": {
                   "type": "PATTERN",
                   "value": "[eE][nN][dD][tT][yY][pP][eE]"
-                }
-              ]
-            },
-            "named": false,
-            "value": "endtype"
+                },
+                "named": false,
+                "value": "endtype"
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -11814,31 +11904,41 @@
           "value": "real"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[dD][oO][uU][bB][lL][eE]"
                   },
-                  {
+                  "named": false,
+                  "value": "double"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[pP][rR][eE][cC][iI][sS][iI][oO][nN]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "precision"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[dD][oO][uU][bB][lL][eE][pP][rR][eE][cC][iI][sS][iI][oO][nN]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "doubleprecision"
+              },
+              "named": false,
+              "value": "doubleprecision"
+            }
+          ]
         },
         {
           "type": "ALIAS",
@@ -11850,31 +11950,41 @@
           "value": "complex"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[dD][oO][uU][bB][lL][eE]"
                   },
-                  {
+                  "named": false,
+                  "value": "double"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[cC][oO][mM][pP][lL][eE][xX]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "complex"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[dD][oO][uU][bB][lL][eE][cC][oO][mM][pP][lL][eE][xX]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "doublecomplex"
+              },
+              "named": false,
+              "value": "doublecomplex"
+            }
+          ]
         },
         {
           "type": "ALIAS",
@@ -12335,31 +12445,41 @@
                   "value": "out"
                 },
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "ALIAS",
+                          "content": {
                             "type": "PATTERN",
                             "value": "[iI][nN]"
                           },
-                          {
+                          "named": false,
+                          "value": "in"
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
                             "type": "PATTERN",
                             "value": "[oO][uU][tT]"
-                          }
-                        ]
-                      },
-                      {
+                          },
+                          "named": false,
+                          "value": "out"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
                         "type": "PATTERN",
                         "value": "[iI][nN][oO][uU][tT]"
-                      }
-                    ]
-                  },
-                  "named": false,
-                  "value": "inout"
+                      },
+                      "named": false,
+                      "value": "inout"
+                    }
+                  ]
                 }
               ]
             },
@@ -13335,31 +13455,41 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "ALIAS",
+                      "content": {
                         "type": "PATTERN",
                         "value": "[gG][oO]"
                       },
-                      {
+                      "named": false,
+                      "value": "go"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
                         "type": "PATTERN",
                         "value": "[tT][oO]"
-                      }
-                    ]
-                  },
-                  {
+                      },
+                      "named": false,
+                      "value": "to"
+                    }
+                  ]
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[gG][oO][tT][oO]"
-                  }
-                ]
-              },
-              "named": false,
-              "value": "goto"
+                  },
+                  "named": false,
+                  "value": "goto"
+                }
+              ]
             },
             {
               "type": "CHOICE",
@@ -13928,31 +14058,41 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[eE][nN][dD]"
                   },
-                  {
+                  "named": false,
+                  "value": "end"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[dD][oO]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "do"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[eE][nN][dD][dD][oO]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "enddo"
+              },
+              "named": false,
+              "value": "enddo"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -14013,31 +14153,41 @@
             "name": "statement_label"
           },
           {
-            "type": "ALIAS",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
                       "type": "PATTERN",
                       "value": "[eE][nN][dD]"
                     },
-                    {
+                    "named": false,
+                    "value": "end"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
                       "type": "PATTERN",
                       "value": "[dD][oO]"
-                    }
-                  ]
-                },
-                {
+                    },
+                    "named": false,
+                    "value": "do"
+                  }
+                ]
+              },
+              {
+                "type": "ALIAS",
+                "content": {
                   "type": "PATTERN",
                   "value": "[eE][nN][dD][dD][oO]"
-                }
-              ]
-            },
-            "named": false,
-            "value": "enddo"
+                },
+                "named": false,
+                "value": "enddo"
+              }
+            ]
           }
         ]
       }
@@ -14592,31 +14742,41 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[eE][nN][dD]"
                   },
-                  {
+                  "named": false,
+                  "value": "end"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[iI][fF]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "if"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[eE][nN][dD][iI][fF]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "endif"
+              },
+              "named": false,
+              "value": "endif"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -14636,31 +14796,41 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[eE][lL][sS][eE]"
                   },
-                  {
+                  "named": false,
+                  "value": "else"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[iI][fF]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "if"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[eE][lL][sS][eE][iI][fF]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "elseif"
+              },
+              "named": false,
+              "value": "elseif"
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -14832,31 +15002,41 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[eE][nN][dD]"
                   },
-                  {
+                  "named": false,
+                  "value": "end"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[wW][hH][eE][rR][eE]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "where"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[eE][nN][dD][wW][hH][eE][rR][eE]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "endwhere"
+              },
+              "named": false,
+              "value": "endwhere"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -14876,31 +15056,41 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[eE][lL][sS][eE]"
                   },
-                  {
+                  "named": false,
+                  "value": "else"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[wW][hH][eE][rR][eE]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "where"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[eE][lL][sS][eE][wW][hH][eE][rR][eE]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "elsewhere"
+              },
+              "named": false,
+              "value": "elsewhere"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -15140,31 +15330,41 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[eE][nN][dD]"
                   },
-                  {
+                  "named": false,
+                  "value": "end"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[fF][oO][rR][aA][lL][lL]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "forall"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[eE][nN][dD][fF][oO][rR][aA][lL][lL]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "endforall"
+              },
+              "named": false,
+              "value": "endforall"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -15196,31 +15396,41 @@
           ]
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[sS][eE][lL][eE][cC][tT]"
                   },
-                  {
+                  "named": false,
+                  "value": "select"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[cC][aA][sS][eE]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "case"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[sS][eE][lL][eE][cC][tT][cC][aA][sS][eE]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "selectcase"
+              },
+              "named": false,
+              "value": "selectcase"
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -15310,31 +15520,41 @@
           ]
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[sS][eE][lL][eE][cC][tT]"
                   },
-                  {
+                  "named": false,
+                  "value": "select"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[tT][yY][pP][eE]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "type"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[sS][eE][lL][eE][cC][tT][tT][yY][pP][eE]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "selecttype"
+              },
+              "named": false,
+              "value": "selecttype"
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -15424,31 +15644,41 @@
           ]
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[sS][eE][lL][eE][cC][tT]"
                   },
-                  {
+                  "named": false,
+                  "value": "select"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[rR][aA][nN][kK]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "rank"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[sS][eE][lL][eE][cC][tT][rR][aA][nN][kK]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "selectrank"
+              },
+              "named": false,
+              "value": "selectrank"
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -15526,31 +15756,41 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[eE][nN][dD]"
                   },
-                  {
+                  "named": false,
+                  "value": "end"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[sS][eE][lL][eE][cC][tT]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "select"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[eE][nN][dD][sS][eE][lL][eE][cC][tT]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "endselect"
+              },
+              "named": false,
+              "value": "endselect"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -15678,58 +15918,78 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SEQ",
-                            "members": [
-                              {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "ALIAS",
+                              "content": {
                                 "type": "PATTERN",
                                 "value": "[tT][yY][pP][eE]"
                               },
-                              {
+                              "named": false,
+                              "value": "type"
+                            },
+                            {
+                              "type": "ALIAS",
+                              "content": {
                                 "type": "PATTERN",
                                 "value": "[iI][sS]"
-                              }
-                            ]
-                          },
-                          {
+                              },
+                              "named": false,
+                              "value": "is"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
                             "type": "PATTERN",
                             "value": "[tT][yY][pP][eE][iI][sS]"
-                          }
-                        ]
-                      },
-                      "named": false,
-                      "value": "typeis"
+                          },
+                          "named": false,
+                          "value": "typeis"
+                        }
+                      ]
                     },
                     {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SEQ",
-                            "members": [
-                              {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "ALIAS",
+                              "content": {
                                 "type": "PATTERN",
                                 "value": "[cC][lL][aA][sS][sS]"
                               },
-                              {
+                              "named": false,
+                              "value": "class"
+                            },
+                            {
+                              "type": "ALIAS",
+                              "content": {
                                 "type": "PATTERN",
                                 "value": "[iI][sS]"
-                              }
-                            ]
-                          },
-                          {
+                              },
+                              "named": false,
+                              "value": "is"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
                             "type": "PATTERN",
                             "value": "[cC][lL][aA][sS][sS][iI][sS]"
-                          }
-                        ]
-                      },
-                      "named": false,
-                      "value": "classis"
+                          },
+                          "named": false,
+                          "value": "classis"
+                        }
+                      ]
                     }
                   ]
                 },
@@ -16000,31 +16260,41 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[eE][nN][dD]"
                   },
-                  {
+                  "named": false,
+                  "value": "end"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[bB][lL][oO][cC][kK]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "block"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[eE][nN][dD][bB][lL][oO][cC][kK]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "endblock"
+              },
+              "named": false,
+              "value": "endblock"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -16143,31 +16413,41 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[eE][nN][dD]"
                   },
-                  {
+                  "named": false,
+                  "value": "end"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[aA][sS][sS][oO][cC][iI][aA][tT][eE]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "associate"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[eE][nN][dD][aA][sS][sS][oO][cC][iI][aA][tT][eE]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "endassociate"
+              },
+              "named": false,
+              "value": "endassociate"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -17009,31 +17289,41 @@
       ]
     },
     "end_enum_statement": {
-      "type": "ALIAS",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SEQ",
-            "members": [
-              {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[eE][nN][dD]"
               },
-              {
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[eE][nN][uU][mM]"
-              }
-            ]
-          },
-          {
+              },
+              "named": false,
+              "value": "enum"
+            }
+          ]
+        },
+        {
+          "type": "ALIAS",
+          "content": {
             "type": "PATTERN",
             "value": "[eE][nN][dD][eE][nN][uU][mM]"
-          }
-        ]
-      },
-      "named": false,
-      "value": "endenum"
+          },
+          "named": false,
+          "value": "endenum"
+        }
+      ]
     },
     "end_enumeration_type_statement": {
       "type": "SEQ",
@@ -19989,31 +20279,41 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[eE][nN][dD]"
                   },
-                  {
+                  "named": false,
+                  "value": "end"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[tT][eE][aA][mM]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "team"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[eE][nN][dD][tT][eE][aA][mM]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "endteam"
+              },
+              "named": false,
+              "value": "endteam"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -20098,31 +20398,41 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[eE][nN][dD]"
                   },
-                  {
+                  "named": false,
+                  "value": "end"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "PATTERN",
                     "value": "[cC][rR][iI][tT][iI][cC][aA][lL]"
-                  }
-                ]
-              },
-              {
+                  },
+                  "named": false,
+                  "value": "critical"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "PATTERN",
                 "value": "[eE][nN][dD][cC][rR][iI][tT][iI][cC][aA][lL]"
-              }
-            ]
-          },
-          "named": false,
-          "value": "endcritical"
+              },
+              "named": false,
+              "value": "endcritical"
+            }
+          ]
         },
         {
           "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -14311,6 +14311,10 @@
     "named": false
   },
   {
+    "type": "is",
+    "named": false
+  },
+  {
     "type": "kind",
     "named": false
   },
@@ -14420,6 +14424,10 @@
   },
   {
     "type": "post",
+    "named": false
+  },
+  {
+    "type": "precision",
     "named": false
   },
   {


### PR DESCRIPTION
Previously, `end program` would be captured as:

    end_program_statement
      "endprogram"
      "endprogram"

and now it will be captured as:

    end_program_statement
      "end"
      "program"

and `endprogram` will be captured as:

    end_program_statement
      "endprogram"

(this is the same as before).

These are the outputs from `tree-sitter parse --cst`, which shows the concrete syntax tree, including anonymous nodes. Annoyingly, because they are anonymous, they don't appear in the S-expressions in the tests, so we can't test for these.