### PR TITLE
Fix string literals immediately followed by line continuation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ tree-sitter-language = "0.1.0"
 cc = "1.0"
 
 [dev-dependencies]
-tree-sitter = "0.24"
+tree-sitter = "0.25"

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "prebuildify": "^6.0.0",
-    "tree-sitter-cli": "^0.24.7"
+    "tree-sitter-cli": "^0.25.4"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.22.4"
+    "tree-sitter": "^0.25.4"
   },
   "peerDependenciesMeta": {
     "tree_sitter": {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7949,21 +7949,26 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "ALIAS",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
                       "type": "PATTERN",
                       "value": "[eE][nN][dD]"
                     },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
+                    "named": false,
+                    "value": "end"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "ALIAS",
+                        "content": {
                           "type": "CHOICE",
                           "members": [
                             {
@@ -7985,21 +7990,26 @@
                             }
                           ]
                         },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
+                        "named": false,
+                        "value": "blockdata"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "ALIAS",
+                "content": {
                   "type": "PATTERN",
                   "value": "[eE][nN][dD][[oO][bB][jJ][eE][cC][tT] O[bB][jJ][eE][cC][tT]]"
-                }
-              ]
-            },
-            "named": false,
-            "value": "end[object Object]"
+                },
+                "named": false,
+                "value": "endblockdata"
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -21248,5 +21258,6 @@
     "_top_level_item",
     "_statement"
   ],
-  "supertypes": []
+  "supertypes": [],
+  "reserved": {}
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -13676,7 +13676,8 @@
   },
   {
     "type": "&",
-    "named": false
+    "named": false,
+    "extra": true
   },
   {
     "type": "&&",
@@ -13972,7 +13973,8 @@
   },
   {
     "type": "comment",
-    "named": true
+    "named": true,
+    "extra": true
   },
   {
     "type": "common",
@@ -14071,15 +14073,15 @@
     "named": false
   },
   {
-    "type": "end[object Object]",
-    "named": false
-  },
-  {
     "type": "endassociate",
     "named": false
   },
   {
     "type": "endblock",
+    "named": false
+  },
+  {
+    "type": "endblockdata",
     "named": false
   },
   {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -197,7 +197,7 @@ static bool scan_hollerith_constant(TSLexer *lexer) {
     advance(lexer);
 
     // Read exactly 'n' characters
-    for (int i = 0; i < length; i++) {
+    for (unsigned i = 0; i < length; i++) {
         if (!lexer->lookahead || lexer->eof(lexer)) {
             return false;
         }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -153,13 +153,13 @@ static bool skip_literal_continuation_sequence(TSLexer *lexer) {
         return true;
     }
 
-    skip(lexer);
+    advance(lexer);
     while (iswspace(lexer->lookahead)) {
-        skip(lexer);
+        advance(lexer);
     }
-    // second '&' required to continue the literal
+    // second '&' technically required to continue the literal
     if (lexer->lookahead == '&') {
-        skip(lexer);
+        advance(lexer);
         return true;
     }
     return false;
@@ -365,6 +365,7 @@ static bool scan_string_literal(TSLexer *lexer) {
             // the end of the literal. We also need to check that an
             // escaped quote isn't split in half by a line
             // continuation -- people do this!
+            lexer->mark_end(lexer);
             skip_literal_continuation_sequence(lexer);
             if (lexer->lookahead != opening_quote) {
                 return true;

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,6 +18,11 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -26,10 +31,11 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
+// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSFieldMapSlice;
+} TSMapSlice;
 
 typedef struct {
   bool visible;
@@ -79,6 +85,12 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
 typedef union {
   TSParseAction action;
   struct {
@@ -93,7 +105,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t version;
+  uint32_t abi_version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -109,13 +121,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
+  const TSMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexMode *lex_modes;
+  const TSLexerMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -129,15 +141,23 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
+    const TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -145,7 +165,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }
     size -= half_size;
   }
-  TSCharacterRange *range = &ranges[index];
+  const TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 


### PR DESCRIPTION
Previously:

```f90
print*, 'this looks like implicit '&
     'concatenation but isn''t'
print*, "this explicit concatenation "&
     // "is intended"
```

would get parsed as

```
8:2   - 9:33        print_statement
8:2   - 8:7           "print"
8:7   - 8:8           format_identifier
8:7   - 8:8             "*"
8:8   - 8:9           ","
9:7   - 9:33          output_item_list
9:7   - 9:33            string_literal `'concatenation but isn''t'`
10:2  - 11:23       print_statement
10:2  - 10:7          "print"
10:7  - 10:8          format_identifier
10:7  - 10:8            "*"
10:8  - 10:9          ","
11:7  - 11:23         output_item_list
11:7  - 11:23           concatenation_expression
11:7  - 11:7              left: string_literal
11:7  - 11:9              "//"
11:10 - 11:23             right: string_literal `"is intended"`
```

Note first half of literal is missing!

Now gets parsed as:

```
8:2   - 9:33        print_statement
8:2   - 8:7           "print"
8:7   - 8:8           format_identifier
8:7   - 8:8             "*"
8:8   - 8:9           ","
8:10  - 9:33          output_item_list
8:10  - 9:33            string_literal
8:10  - 8:39              `'this looks like implicit '&\n`
9:10  - 9:33              `       'concatenation but isn''t'`
10:2  - 11:23       print_statement
10:2  - 10:7          "print"
10:7  - 10:8          format_identifier
10:7  - 10:8            "*"
10:8  - 10:9          ","
10:10 - 11:23         output_item_list
10:10 - 11:23           concatenation_expression
10:10 - 10:40             left: string_literal `"this explicit concatenation "`
10:40 - 10:41             "&"
11:7  - 11:7              "&"
11:7  - 11:9              "//"
11:10 - 11:23             right: string_literal `"is intended"`
```

Full literal text is now included.

No tests because this is in the CST, and that's not captured in the tests