### PR TITLE
More extensions and edge cases

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -895,11 +895,16 @@ module.exports = grammar({
       '=>',
       field('right', $._expression)
     ),
+    data_declarator: $ => seq(
+      field('left', $._variable_declarator),
+      field('right', $.data_value),
+    ),
 
     _declaration_targets: $ => commaSep1(field('declarator', choice(
       $._variable_declarator,
       alias($._declaration_assignment, $.init_declarator),
       alias($._declaration_pointer_association, $.pointer_init_declarator),
+      $.data_declarator,
     ))),
 
     _intrinsic_type: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -1988,6 +1988,10 @@ module.exports = grammar({
       '(',
       commaSep1($._expression),
       ',',
+      // This should really be _inside_ loop_control_expression, but
+      // type-spec only valid here, and not other places that use
+      // loop_control_expression
+      optional(seq(field('type', $.intrinsic_type), '::')),
       $.loop_control_expression,
       ')'
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -969,6 +969,7 @@ module.exports = grammar({
     _standalone_type_qualifier: $ => choice(
       caseInsensitive('abstract'),
       caseInsensitive('allocatable'),
+      caseInsensitive('asynchronous'),
       caseInsensitive('automatic'),
       prec.right(seq(
         caseInsensitive('codimension'),
@@ -2239,6 +2240,7 @@ module.exports = grammar({
     identifier: $ => choice(
       /[a-zA-Z_$][\w$]*/,
       caseInsensitive('allocatable'),
+      caseInsensitive('asynchronous'),
       caseInsensitive('automatic'),
       caseInsensitive('block'),
       caseInsensitive('byte'),

--- a/grammar.js
+++ b/grammar.js
@@ -1465,7 +1465,7 @@ module.exports = grammar({
       whiteSpacedKeyword('select', 'case'),
       $.selector,
       $._end_of_statement,
-      repeat1(choice(
+      repeat(choice(
         $.case_statement,
         $.preproc_include,
         $.preproc_def,
@@ -1483,7 +1483,7 @@ module.exports = grammar({
       whiteSpacedKeyword('select', 'type'),
       $.selector,
       $._end_of_statement,
-      repeat1(choice(
+      repeat(choice(
         $.type_statement,
         $.preproc_include,
         $.preproc_def,
@@ -1501,7 +1501,7 @@ module.exports = grammar({
       whiteSpacedKeyword('select', 'rank'),
       $.selector,
       $._end_of_statement,
-      repeat1(choice(
+      repeat(choice(
         $.rank_statement,
         $.preproc_include,
         $.preproc_def,

--- a/grammar.js
+++ b/grammar.js
@@ -616,7 +616,10 @@ module.exports = grammar({
       caseInsensitive('implicit'),
       choice(
         commaSep1(seq(
-          $.intrinsic_type,
+          choice(
+            $.intrinsic_type,
+            $.derived_type
+          ),
           '(',
           commaSep1($.implicit_range),
           ')'
@@ -842,7 +845,10 @@ module.exports = grammar({
     procedure_declaration: $ => seq(
       caseInsensitive('procedure'),
       optional(seq(
-        '(', optional(alias($.identifier, $.procedure_interface)), ')'
+        '(',
+        optional(
+          alias($.identifier, $.procedure_interface)),
+        ')'
       )),
       optional(seq(',', commaSep1($.procedure_attribute))),
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -2139,7 +2139,10 @@ module.exports = grammar({
       // is _really_ hard to parse without breaking other things, so
       // we have to rely on an external scanner
       optional(seq(
-        field('kind', alias($._string_literal_kind, $.identifier)),
+        field('kind', choice(
+          alias($._string_literal_kind, $.identifier),
+          alias($._integer_literal, $.number_literal)
+        )),
         // Although external scanner enforces trailing underscore, we
         // also need to *capture* it here
         token.immediate('_'),

--- a/grammar.js
+++ b/grammar.js
@@ -2104,7 +2104,13 @@ module.exports = grammar({
     ),
 
     null_literal: $ => prec(1, seq(
-      caseInsensitive('null'), '(', ')'
+      caseInsensitive('null'),
+      '(',
+      optional(field('mold', choice(
+        $.identifier,
+        $.derived_type_member_expression,
+      ))),
+      ')',
     )),
 
     string_literal: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -101,6 +101,7 @@ module.exports = grammar({
     [$._inline_if_statement, $.arithmetic_if_statement, $._block_if_statement, $.identifier],
     [$.file_position_statement, $.identifier],
     [$.cray_pointer_declaration, $.identifier],
+    [$.unit_identifier, $.identifier],
   ],
 
   supertypes: $ => [
@@ -1759,14 +1760,20 @@ module.exports = grammar({
     ),
 
     // precedence is used to override a conflict with the complex literal
-    unit_identifier: $ => prec(1, choice(
-      $.number_literal,
-      $._io_expressions
-    )),
+    unit_identifier: $ => seq(
+      optional(seq(caseInsensitive('unit'), '=')),
+      prec(1, choice(
+        $.number_literal,
+        $._io_expressions
+      ))
+    ),
 
-    format_identifier: $ => choice(
-      $.statement_label_reference,
-      $._io_expressions
+    format_identifier: $ => seq(
+      optional(seq(caseInsensitive('fmt'), '=')),
+      choice(
+        $.statement_label_reference,
+        $._io_expressions
+      )
     ),
 
     _file_position_spec: $ => choice(
@@ -2326,6 +2333,7 @@ module.exports = grammar({
       caseInsensitive('target'),
       caseInsensitive('texture'),
       prec(-1, caseInsensitive('type')),
+      caseInsensitive('unit'),
       caseInsensitive('unlock'),
       caseInsensitive('value'),
       caseInsensitive('wait'),

--- a/grammar.js
+++ b/grammar.js
@@ -561,6 +561,7 @@ module.exports = grammar({
       $.import_statement,
       $.public_statement,
       $.private_statement,
+      $.bind_statement,
       $.enum,
       $.enumeration_type,
       $.namelist_statement,
@@ -640,14 +641,21 @@ module.exports = grammar({
 
     save_statement: $ => prec(1, seq(
       caseInsensitive('save'),
-      optional(seq(
-        optional('::'),
-        commaSep1(choice(
-          $.identifier,
-          seq('/', $.identifier, '/'),
-        )),
-      )),
+      optional($._identifier_or_common_block),
     )),
+
+    bind_statement: $ => seq(
+      $.language_binding,
+      $._identifier_or_common_block,
+    ),
+
+    _identifier_or_common_block: $ => seq(
+      optional('::'),
+      commaSep1(choice(
+        $.identifier,
+        seq('/', alias($.identifier, $.common_block), '/'),
+      )),
+    ),
 
     private_statement: $ => prec.right(1, seq(
       caseInsensitive('private'),
@@ -863,7 +871,6 @@ module.exports = grammar({
       repeat1(choice(
         alias($._standalone_type_qualifier, $.type_qualifier),
         $.variable_attributes,
-        $.language_binding,
       )),
       optional('::'),
       commaSep1(field('declarator', $._variable_declarator)),

--- a/grammar.js
+++ b/grammar.js
@@ -847,7 +847,12 @@ module.exports = grammar({
       optional(seq(
         '(',
         optional(
-          alias($.identifier, $.procedure_interface)),
+          choice(
+            alias($.identifier, $.procedure_interface),
+            $.intrinsic_type,
+            $.derived_type,
+          )
+        ),
         ')'
       )),
       optional(seq(',', commaSep1($.procedure_attribute))),

--- a/grammar.js
+++ b/grammar.js
@@ -573,6 +573,8 @@ module.exports = grammar({
       $.cray_pointer_declaration,
       // This catches statement functions, which are completely ambiguous
       $.assignment_statement,
+      // This can appear immediately after procedure statement, or after `return`
+      $.entry_statement,
     )),
 
     use_statement: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -717,7 +717,7 @@ module.exports = grammar({
           ),
           $._end_of_statement
         ),
-        $.variable_declaration,
+        seq($.variable_declaration, $._end_of_statement),
         $.preproc_include,
         $.preproc_def,
         $.preproc_function_def,
@@ -758,6 +758,7 @@ module.exports = grammar({
         seq(',', commaSep1($._derived_type_qualifier), '::', $._type_name)
       ),
       optional(alias($.argument_list, $.derived_type_parameter_list)),
+      $._end_of_statement,
     ),
 
     end_type_statement: $ => blockStructureEnding($, 'type'),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -19930,6 +19930,31 @@
             "value": "("
           },
           {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "mold",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "derived_type_member_expression"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
             "type": "STRING",
             "value": ")"
           }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -20049,13 +20049,27 @@
                   "type": "FIELD",
                   "name": "kind",
                   "content": {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "_string_literal_kind"
-                    },
-                    "named": true,
-                    "value": "identifier"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_string_literal_kind"
+                        },
+                        "named": true,
+                        "value": "identifier"
+                      },
+                      {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_integer_literal"
+                        },
+                        "named": true,
+                        "value": "number_literal"
+                      }
+                    ]
                   }
                 },
                 {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -15468,7 +15468,7 @@
           "name": "_end_of_statement"
         },
         {
-          "type": "REPEAT1",
+          "type": "REPEAT",
           "content": {
             "type": "CHOICE",
             "members": [
@@ -15592,7 +15592,7 @@
           "name": "_end_of_statement"
         },
         {
-          "type": "REPEAT1",
+          "type": "REPEAT",
           "content": {
             "type": "CHOICE",
             "members": [
@@ -15716,7 +15716,7 @@
           "name": "_end_of_statement"
         },
         {
-          "type": "REPEAT1",
+          "type": "REPEAT",
           "content": {
             "type": "CHOICE",
             "members": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -19248,6 +19248,31 @@
           "value": ","
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "type",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "intrinsic_type"
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": "::"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "loop_control_expression"
         },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9377,6 +9377,10 @@
           {
             "type": "SYMBOL",
             "name": "assignment_statement"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "entry_statement"
           }
         ]
       }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -17460,32 +17460,94 @@
       ]
     },
     "unit_identifier": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "number_literal"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_io_expressions"
-          }
-        ]
-      }
-    },
-    "format_identifier": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "statement_label_reference"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[uU][nN][iI][tT]"
+                  },
+                  "named": false,
+                  "value": "unit"
+                },
+                {
+                  "type": "STRING",
+                  "value": "="
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_io_expressions"
+          "type": "PREC",
+          "value": 1,
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "number_literal"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_io_expressions"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "format_identifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[fF][mM][tT]"
+                  },
+                  "named": false,
+                  "value": "fmt"
+                },
+                {
+                  "type": "STRING",
+                  "value": "="
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "statement_label_reference"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_io_expressions"
+            }
+          ]
         }
       ]
     },
@@ -21392,6 +21454,15 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
+            "value": "[uU][nN][iI][tT]"
+          },
+          "named": false,
+          "value": "unit"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
             "value": "[uU][nN][lL][oO][cC][kK]"
           },
           "named": false,
@@ -21576,6 +21647,10 @@
     ],
     [
       "cray_pointer_declaration",
+      "identifier"
+    ],
+    [
+      "unit_identifier",
       "identifier"
     ]
   ],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9336,6 +9336,10 @@
           },
           {
             "type": "SYMBOL",
+            "name": "bind_statement"
+          },
+          {
+            "type": "SYMBOL",
             "name": "enum"
           },
           {
@@ -9878,90 +9882,8 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "::"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "identifier"
-                          },
-                          {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": "/"
-                              },
-                              {
-                                "type": "SYMBOL",
-                                "name": "identifier"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "/"
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "type": "REPEAT",
-                        "content": {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ","
-                            },
-                            {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "identifier"
-                                },
-                                {
-                                  "type": "SEQ",
-                                  "members": [
-                                    {
-                                      "type": "STRING",
-                                      "value": "/"
-                                    },
-                                    {
-                                      "type": "SYMBOL",
-                                      "name": "identifier"
-                                    },
-                                    {
-                                      "type": "STRING",
-                                      "value": "/"
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ]
+                "type": "SYMBOL",
+                "name": "_identifier_or_common_block"
               },
               {
                 "type": "BLANK"
@@ -9970,6 +9892,115 @@
           }
         ]
       }
+    },
+    "bind_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "language_binding"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_identifier_or_common_block"
+        }
+      ]
+    },
+    "_identifier_or_common_block": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "::"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "/"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      "named": true,
+                      "value": "common_block"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "/"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "/"
+                          },
+                          {
+                            "type": "ALIAS",
+                            "content": {
+                              "type": "SYMBOL",
+                              "name": "identifier"
+                            },
+                            "named": true,
+                            "value": "common_block"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "/"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
     },
     "private_statement": {
       "type": "PREC_RIGHT",
@@ -11504,10 +11535,6 @@
               {
                 "type": "SYMBOL",
                 "name": "variable_attributes"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "language_binding"
               }
             ]
           }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -11390,13 +11390,26 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "identifier"
-                      },
-                      "named": true,
-                      "value": "procedure_interface"
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "identifier"
+                          },
+                          "named": true,
+                          "value": "procedure_interface"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "intrinsic_type"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "derived_type"
+                        }
+                      ]
                     },
                     {
                       "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9645,8 +9645,17 @@
                   "type": "SEQ",
                   "members": [
                     {
-                      "type": "SYMBOL",
-                      "name": "intrinsic_type"
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "intrinsic_type"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "derived_type"
+                        }
+                      ]
                     },
                     {
                       "type": "STRING",
@@ -9696,8 +9705,17 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "SYMBOL",
-                            "name": "intrinsic_type"
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SYMBOL",
+                                "name": "intrinsic_type"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "derived_type"
+                              }
+                            ]
                           },
                           {
                             "type": "STRING",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -12251,6 +12251,15 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
+            "value": "[aA][sS][yY][nN][cC][hH][rR][oO][nN][oO][uU][sS]"
+          },
+          "named": false,
+          "value": "asynchronous"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
             "value": "[aA][uU][tT][oO][mM][aA][tT][iI][cC]"
           },
           "named": false,
@@ -20732,6 +20741,15 @@
           },
           "named": false,
           "value": "allocatable"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[aA][sS][yY][nN][cC][hH][rR][oO][nN][oO][uU][sS]"
+          },
+          "named": false,
+          "value": "asynchronous"
         },
         {
           "type": "ALIAS",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -11707,6 +11707,27 @@
         }
       ]
     },
+    "data_declarator": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "left",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_variable_declarator"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "right",
+          "content": {
+            "type": "SYMBOL",
+            "name": "data_value"
+          }
+        }
+      ]
+    },
     "_declaration_targets": {
       "type": "SEQ",
       "members": [
@@ -11737,6 +11758,10 @@
                 },
                 "named": true,
                 "value": "pointer_init_declarator"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "data_declarator"
               }
             ]
           }
@@ -11777,6 +11802,10 @@
                       },
                       "named": true,
                       "value": "pointer_init_declarator"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "data_declarator"
                     }
                   ]
                 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10492,8 +10492,17 @@
                 ]
               },
               {
-                "type": "SYMBOL",
-                "name": "variable_declaration"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "variable_declaration"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_end_of_statement"
+                  }
+                ]
               },
               {
                 "type": "SYMBOL",
@@ -10745,6 +10754,10 @@
               "type": "BLANK"
             }
           ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_of_statement"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5279,6 +5279,14 @@
       "required": false,
       "types": [
         {
+          "type": "derived_type",
+          "named": true
+        },
+        {
+          "type": "intrinsic_type",
+          "named": true
+        },
+        {
           "type": "procedure_attribute",
           "named": true
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1703,6 +1703,40 @@
     }
   },
   {
+    "type": "data_declarator",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "coarray_declarator",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "sized_declarator",
+            "named": true
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "data_value",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "data_set",
     "named": true,
     "fields": {},
@@ -6514,6 +6548,10 @@
         "types": [
           {
             "type": "coarray_declarator",
+            "named": true
+          },
+          {
+            "type": "data_declarator",
             "named": true
           },
           {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3298,7 +3298,18 @@
   {
     "type": "implied_do_loop_expression",
     "named": true,
-    "fields": {},
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "intrinsic_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -7443,6 +7443,10 @@
     "named": false
   },
   {
+    "type": "fmt",
+    "named": false
+  },
+  {
     "type": "forall",
     "named": false
   },
@@ -7856,6 +7860,10 @@
   },
   {
     "type": "unformatted",
+    "named": false
+  },
+  {
+    "type": "unit",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4133,7 +4133,22 @@
   {
     "type": "null_literal",
     "named": true,
-    "fields": {}
+    "fields": {
+      "mold": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "derived_type_member_expression",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    }
   },
   {
     "type": "nullify_statement",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -7063,6 +7063,10 @@
     "named": true
   },
   {
+    "type": "asynchronous",
+    "named": false
+  },
+  {
     "type": "attributes",
     "named": false
   },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -116,6 +116,10 @@
         "named": true
       },
       {
+        "type": "bind_statement",
+        "named": true
+      },
+      {
         "type": "common_statement",
         "named": true
       },
@@ -803,6 +807,29 @@
     "fields": {}
   },
   {
+    "type": "bind_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "common_block",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "language_binding",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "binding",
     "named": true,
     "fields": {},
@@ -1392,6 +1419,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "common_block",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "common_statement",
@@ -5650,6 +5682,10 @@
       "required": false,
       "types": [
         {
+          "type": "common_block",
+          "named": true
+        },
+        {
           "type": "identifier",
           "named": true
         }
@@ -6692,10 +6728,6 @@
       "multiple": true,
       "required": true,
       "types": [
-        {
-          "type": "language_binding",
-          "named": true
-        },
         {
           "type": "type_qualifier",
           "named": true

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3285,6 +3285,10 @@
       "required": true,
       "types": [
         {
+          "type": "derived_type",
+          "named": true
+        },
+        {
           "type": "implicit_range",
           "named": true
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -128,6 +128,10 @@
         "named": true
       },
       {
+        "type": "entry_statement",
+        "named": true
+      },
+      {
         "type": "enum",
         "named": true
       },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2953,6 +2953,10 @@
           {
             "type": "identifier",
             "named": true
+          },
+          {
+            "type": "number_literal",
+            "named": true
           }
         ]
       }
@@ -5972,6 +5976,10 @@
         "types": [
           {
             "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "number_literal",
             "named": true
           }
         ]

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -48,6 +48,8 @@ static bool is_exp_sentinel(char chr) {
         case 'd':
         case 'E':
         case 'e':
+        case 'Q':
+        case 'q':
             return true;
         default:
             return false;

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -1250,9 +1250,10 @@ module test
     end subroutine do_nothing
   end interface
 contains
-  subroutine apply(f, g)
+  subroutine apply(f, g, h)
     procedure(do_nothing) :: f
     procedure(do_nothing), optional :: g
+    procedure(real(kind=real64)), optional :: h
     call f()
   end subroutine apply
 end module test
@@ -1279,6 +1280,7 @@ end module test
           (name)
           (parameters
             (identifier)
+            (identifier)
             (identifier)))
         (variable_declaration
           (procedure
@@ -1287,6 +1289,15 @@ end module test
         (variable_declaration
           (procedure
             (procedure_interface))
+          (type_qualifier)
+          (identifier))
+        (variable_declaration
+          (procedure
+            (intrinsic_type
+              (kind
+                (keyword_argument
+                  (identifier)
+                  (identifier)))))
           (type_qualifier)
           (identifier))
         (subroutine_call

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -1091,7 +1091,7 @@ Derived Type Procedure Pointer Components
 
 program test
   type foo
-    procedure(some_interface), pointer :: bar => null()
+    procedure(some_interface), pointer :: bar => null(), jaff => null(bar)
     procedure(some_interface), pointer, nopass :: quux
   end type foo
 end program test
@@ -1111,7 +1111,11 @@ end program test
           (procedure_attribute))
         (pointer_init_declarator
           (identifier)
-          (null_literal)))
+          (null_literal))
+        (pointer_init_declarator
+          (identifier)
+          (null_literal
+            (identifier))))
       (variable_declaration
         (procedure
           (procedure_interface)

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -151,6 +151,7 @@ PROGRAM TEST
     val = "one"//'two'//sngl_qt//dble_qt
 
     with_kind = ck_"string with kind"
+    with_numeral_kind = 4_"string with kind"
 END PROGRAM
 
 --------------------------------------------------------------------------------
@@ -196,6 +197,10 @@ END PROGRAM
       left: (identifier)
       right: (string_literal
         kind: (identifier)))
+    (assignment_statement
+      left: (identifier)
+      right: (string_literal
+        kind: (number_literal)))
     (end_program_statement)))
 
 ================================================================================

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -942,7 +942,7 @@ Array Constructors
 program array_constructors
   implicit none
   integer :: i
-  integer, dimension(3) :: array1 = (/ (i, i=1, 3) /)
+  integer, dimension(3) :: array1 = (/ (i, i=1, 3) /), array2 = [(j, integer(kind=8)::j=1,64)]
   real, dimension(10) :: array2
 
   array2 = [((real(i - 1) / 10.), i=1, 10)]
@@ -974,6 +974,20 @@ end program array_constructors
         (array_literal
           (implied_do_loop_expression
             (identifier)
+            (loop_control_expression
+              (identifier)
+              (number_literal)
+              (number_literal)))))
+      (init_declarator
+        (identifier)
+        (array_literal
+          (implied_do_loop_expression
+            (identifier)
+            (intrinsic_type
+              (kind
+                (keyword_argument
+                  (identifier)
+                  (number_literal))))
             (loop_control_expression
               (identifier)
               (number_literal)

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -3419,3 +3419,56 @@ end subroutine pointer_name_clash
       right: (number_literal))
     (end_subroutine_statement
       (name))))
+
+================================================================================
+Data declarators (extension)
+================================================================================
+
+program test
+  implicit none
+  real a(100)/100*1.0/
+  integer(kind=4)::i/1/,j/2/
+  complex x/(1.0, 2.0)/
+end program
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (program
+    (program_statement
+      (name))
+    (implicit_statement
+      (none))
+    (variable_declaration
+      type: (intrinsic_type)
+      declarator: (data_declarator
+        left: (sized_declarator
+          (identifier)
+          (size
+            (number_literal)))
+        right: (data_value
+          repeat: (number_literal)
+          (number_literal))))
+    (variable_declaration
+      type: (intrinsic_type
+        kind: (kind
+          (keyword_argument
+            name: (identifier)
+            value: (number_literal))))
+      declarator: (data_declarator
+        left: (identifier)
+        right: (data_value
+          (number_literal)))
+      declarator: (data_declarator
+        left: (identifier)
+        right: (data_value
+          (number_literal))))
+    (variable_declaration
+      type: (intrinsic_type)
+      declarator: (data_declarator
+        left: (identifier)
+        right: (data_value
+          (complex_literal
+            (number_literal)
+            (number_literal)))))
+    (end_program_statement)))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1427,6 +1427,10 @@ PROGRAM TEST
   CASE DEFAULT
     WRITE(*,*)  'Other characters, which may not be letters'
   END SELECT
+
+  select case (empty)
+  end select
+
 END PROGRAM
 
 --------------------------------------------------------------------------------
@@ -1507,6 +1511,10 @@ END PROGRAM
           (format_identifier)
           (output_item_list
             (string_literal))))
+      (end_select_statement))
+    (select_case_statement
+      (selector
+        (identifier))
       (end_select_statement))
     (end_program_statement)))
 

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -647,9 +647,9 @@ END PROGRAM
     (save_statement
       (identifier)
       (identifier)
-      (identifier)
+      (common_block)
       (identifier))
-    (variable_modification
+    (bind_statement
       (language_binding
         (identifier))
       (identifier))
@@ -3507,3 +3507,33 @@ end program
             (number_literal)
             (number_literal)))))
     (end_program_statement)))
+
+================================================================================
+Standalone Bind(C) Statement
+================================================================================
+
+program test
+  common /foo/ foo
+  integer :: foo
+  bind(C) :: /foo/
+end program test
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (program
+    (program_statement
+      (name))
+    (common_statement
+      (variable_group
+        (name)
+        (identifier)))
+    (variable_declaration
+      (intrinsic_type)
+      (identifier))
+    (bind_statement
+      (language_binding
+        (identifier))
+      (common_block))
+    (end_program_statement
+      (name))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -2856,6 +2856,11 @@ Entry statement (Obsolescent)
        RETURN
        END
 
+       subroutine foo(i)
+       entry      bar(i)
+       integer i
+       end subroutine foo
+
 --------------------------------------------------------------------------------
 
 (translation_unit
@@ -2886,7 +2891,21 @@ Entry statement (Obsolescent)
     (entry_statement
       (name))
     (keyword_statement)
-    (end_subroutine_statement)))
+    (end_subroutine_statement))
+  (subroutine
+    (subroutine_statement
+      (name)
+      (parameters
+        (identifier)))
+    (entry_statement
+      (name)
+      (parameters
+        (identifier)))
+    (variable_declaration
+      (intrinsic_type)
+      (identifier))
+    (end_subroutine_statement
+      (name))))
 
 ================================================================================
 Coarray declarations

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1663,8 +1663,7 @@ END PROGRAM
     (read_statement
       (unit_identifier
         (identifier))
-      (keyword_argument
-        (identifier)
+      (format_identifier
         (string_literal))
       (input_item_list
         (call_expression
@@ -1736,6 +1735,8 @@ PROGRAM TEST
   WRITE(IOUNIT, "(FORMAT STRING)", IOSTAT=IOS)
   WRITE(IOUNIT, FMT="(FORMAT STRING)") flags(:)
   WRITE(UNIT=IOUNIT, FMT="(FORMAT STRING)", IOSTAT=IOS, ADVANCE='NO') X
+  write(unit=77, '(a)') "unusual"
+  write(unit=77, *) "but valid"
 END PROGRAM
 
 --------------------------------------------------------------------------------
@@ -1771,8 +1772,7 @@ END PROGRAM
     (write_statement
       (unit_identifier
         (identifier))
-      (keyword_argument
-        (identifier)
+      (format_identifier
         (string_literal))
       (output_item_list
         (call_expression
@@ -1794,6 +1794,19 @@ END PROGRAM
         (string_literal))
       (output_item_list
         (identifier)))
+    (write_statement
+      (unit_identifier
+        (number_literal))
+      (format_identifier
+        (string_literal))
+      (output_item_list
+        (string_literal)))
+    (write_statement
+      (unit_identifier
+        (number_literal))
+      (format_identifier)
+      (output_item_list
+        (string_literal)))
     (end_program_statement)))
 
 ================================================================================
@@ -2122,8 +2135,7 @@ end program test
         (identifier)
         (string_literal)))
     (close_statement
-      (keyword_argument
-        (identifier)
+      (unit_identifier
         (identifier))
       (keyword_argument
         (identifier)
@@ -2589,8 +2601,7 @@ end program
       (unit_identifier
         (identifier)))
     (file_position_statement
-      (keyword_argument
-        (identifier)
+      (unit_identifier
         (derived_type_member_expression
           (identifier)
           (type_member)))
@@ -2640,8 +2651,7 @@ end program test
               (number_literal)
               (identifier))))))
     (inquire_statement
-      (keyword_argument
-        (identifier)
+      (unit_identifier
         (identifier))
       (keyword_argument
         (identifier)

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -155,6 +155,7 @@ PROGRAM TEST
   IMPLICIT INTEGER(i - n), REAL(8)(r-z),  COMPLEX*8(a - c, d, e-h)
   IMPLICIT NONE
   implicit none (type, external)
+  implicit type(foo)(f), class(bar)(C)
 END PROGRAM
 
 --------------------------------------------------------------------------------
@@ -180,6 +181,13 @@ END PROGRAM
       (none))
     (implicit_statement
       (none))
+    (implicit_statement
+      (derived_type
+        (type_name))
+      (implicit_range)
+      (derived_type
+        (type_name))
+      (implicit_range))
     (end_program_statement)))
 
 ================================================================================


### PR DESCRIPTION
There's a few extensions here (like allowing `1.q0` for quad literals), legacy syntax (`bind(C)::/common_block/`), and uncommon but valid bits (`write(unit=42, *)`)

Closes #138 
Closes #40 

@stadelmanma This and the recent PRs have some breaking changes, please could you release 0.6.0? I will try not to touch things for a bit :)