### PR TITLE
Update highlights.scm to allow better support for detecting function …

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -195,3 +195,6 @@
 
 (derived_type_member_expression
   (type_member) @property)
+
+(call_expression
+  (identifier) @function.call)


### PR DESCRIPTION

![Screenshot_20250731_122600_Termux](https://github.com/user-attachments/assets/ec42f1eb-56cd-40e1-9526-645269da6354)

![Screenshot_20250731_144444_Termux](https://github.com/user-attachments/assets/e912792d-c999-4922-9b04-9f0fb2acee23)
…calls B)

```scm
(call_expression
  (identifier) @function.call)
 ```
 allows for better highlighting of function groups
