### PR TITLE
Add node for `do` statement; rename `do` block node 

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -101,6 +101,7 @@ module.exports = grammar({
     [$._inline_if_statement, $.arithmetic_if_statement, $._block_if_statement, $.identifier],
     [$.cray_pointer_declaration, $.identifier],
     [$.unit_identifier, $.identifier],
+    [$.format_identifier, $.identifier],
   ],
 
   supertypes: $ => [
@@ -2303,6 +2304,7 @@ module.exports = grammar({
       caseInsensitive('external'),
       caseInsensitive('fail'),
       prec(-1, caseInsensitive('flush')),
+      caseInsensitive('fmt'),
       caseInsensitive('form'),
       caseInsensitive('format'),
       caseInsensitive('go'),

--- a/grammar.js
+++ b/grammar.js
@@ -1120,7 +1120,7 @@ module.exports = grammar({
       $.select_case_statement,
       $.select_type_statement,
       $.select_rank_statement,
-      $.do_loop_statement,
+      $.do_loop,
       $.do_label_statement,
       $.end_do_label_statement,
       $.format_statement,
@@ -1257,8 +1257,16 @@ module.exports = grammar({
     ),
     _signed_literal: $ => prec.right(PREC.UNARY, seq(choice('-', '+'), $.number_literal)),
 
-    do_loop_statement: $ => seq(
+    do_loop: $ => seq(
       optional($.block_label_start_expression),
+      $.do_statement,
+      $._end_of_statement,
+      repeat($._statement),
+      optional($.statement_label),
+      $.end_do_loop_statement
+    ),
+
+    do_statement: $ => seq(
       caseInsensitive('do'),
       optional(','),
       optional(choice(
@@ -1266,10 +1274,6 @@ module.exports = grammar({
         $.loop_control_expression,
         $.concurrent_statement
       )),
-      $._end_of_statement,
-      repeat($._statement),
-      optional($.statement_label),
-      $.end_do_loop_statement
     ),
 
     end_do_loop_statement: $ => seq(

--- a/queries/folds.scm
+++ b/queries/folds.scm
@@ -3,7 +3,7 @@
  (if_statement)
  (where_statement)
  (enum_statement)
- (do_loop_statement)
+ (do_loop)
  (derived_type_definition)
  (function)
  (subroutine)

--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -7,7 +7,7 @@
   (function)
   ; (interface)
   (if_statement)
-  (do_loop_statement)
+  (do_loop)
   (where_statement)
   (derived_type_definition)
   (enum)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -21199,6 +21199,15 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
+            "value": "[fF][mM][tT]"
+          },
+          "named": false,
+          "value": "fmt"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
             "value": "[fF][oO][rR][mM]"
           },
           "named": false,
@@ -21695,6 +21704,10 @@
     ],
     [
       "unit_identifier",
+      "identifier"
+    ],
+    [
+      "format_identifier",
       "identifier"
     ]
   ],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -13155,7 +13155,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "do_loop_statement"
+          "name": "do_loop"
         },
         {
           "type": "SYMBOL",
@@ -14106,7 +14106,7 @@
         ]
       }
     },
-    "do_loop_statement": {
+    "do_loop": {
       "type": "SEQ",
       "members": [
         {
@@ -14121,6 +14121,42 @@
             }
           ]
         },
+        {
+          "type": "SYMBOL",
+          "name": "do_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_of_statement"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_statement"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "statement_label"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "end_do_loop_statement"
+        }
+      ]
+    },
+    "do_statement": {
+      "type": "SEQ",
+      "members": [
         {
           "type": "ALIAS",
           "content": {
@@ -14166,33 +14202,6 @@
               "type": "BLANK"
             }
           ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_end_of_statement"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_statement"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "statement_label"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "end_do_loop_statement"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -250,7 +250,7 @@
         "named": true
       },
       {
-        "type": "do_loop_statement",
+        "type": "do_loop",
         "named": true
       },
       {
@@ -2181,7 +2181,7 @@
     }
   },
   {
-    "type": "do_loop_statement",
+    "type": "do_loop",
     "named": true,
     "fields": {},
     "children": {
@@ -2197,15 +2197,11 @@
           "named": true
         },
         {
-          "type": "concurrent_statement",
+          "type": "do_statement",
           "named": true
         },
         {
           "type": "end_do_loop_statement",
-          "named": true
-        },
-        {
-          "type": "loop_control_expression",
           "named": true
         },
         {
@@ -2234,6 +2230,25 @@
         },
         {
           "type": "statement_label",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "do_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "concurrent_statement",
+          "named": true
+        },
+        {
+          "type": "loop_control_expression",
           "named": true
         },
         {

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1729,6 +1729,7 @@ Write Statements
 ================================================================================
 
 PROGRAM TEST
+  character(len=*), parameter :: fmt = '(a)'
   WRITE(*)
   WRITE(*, *) ''
   WRITE(10, 100) x, y, z
@@ -1737,6 +1738,7 @@ PROGRAM TEST
   WRITE(UNIT=IOUNIT, FMT="(FORMAT STRING)", IOSTAT=IOS, ADVANCE='NO') X
   write(unit=77, '(a)') "unusual"
   write(unit=77, *) "but valid"
+  write(unit, fmt) "Test"
 END PROGRAM
 
 --------------------------------------------------------------------------------
@@ -1745,6 +1747,16 @@ END PROGRAM
   (program
     (program_statement
       (name))
+    (variable_declaration
+      (intrinsic_type
+        (kind
+          (keyword_argument
+            (identifier)
+            (assumed_size))))
+      (type_qualifier)
+      (init_declarator
+        (identifier)
+        (string_literal)))
     (write_statement
       (unit_identifier))
     (write_statement
@@ -1805,6 +1817,13 @@ END PROGRAM
       (unit_identifier
         (number_literal))
       (format_identifier)
+      (output_item_list
+        (string_literal)))
+    (write_statement
+      (unit_identifier
+        (identifier))
+      (format_identifier
+        (identifier))
       (output_item_list
         (string_literal)))
     (end_program_statement)))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -693,11 +693,12 @@ END PROGRAM
   (program
     (program_statement
       (name))
-    (do_loop_statement
-      (loop_control_expression
-        (identifier)
-        (number_literal)
-        (number_literal))
+    (do_loop
+      (do_statement
+        (loop_control_expression
+          (identifier)
+          (number_literal)
+          (number_literal)))
       (assignment_statement
         (identifier)
         (math_expression
@@ -717,58 +718,63 @@ END PROGRAM
             (identifier)
             (boolean_literal))))
       (end_do_loop_statement))
-    (do_loop_statement
-      (loop_control_expression
-        (identifier)
-        (number_literal)
-        (call_expression
+    (do_loop
+      (do_statement
+        (loop_control_expression
           (identifier)
-          (argument_list
-            (identifier)))
-        (identifier))
+          (number_literal)
+          (call_expression
+            (identifier)
+            (argument_list
+              (identifier)))
+          (identifier)))
       (keyword_statement)
       (keyword_statement
         (statement_label_reference))
       (end_do_loop_statement))
-    (do_loop_statement
+    (do_loop
       (block_label_start_expression)
-      (loop_control_expression
-        (identifier)
-        (number_literal)
-        (call_expression
-          (identifier)
-          (argument_list
-            (call_expression
-              (identifier)
-              (argument_list
-                (math_expression
-                  (number_literal)
-                  (identifier)))))))
-      (do_loop_statement
+      (do_statement
         (loop_control_expression
           (identifier)
           (number_literal)
-          (number_literal)
-          (unary_expression
-            (number_literal)))
+          (call_expression
+            (identifier)
+            (argument_list
+              (call_expression
+                (identifier)
+                (argument_list
+                  (math_expression
+                    (number_literal)
+                    (identifier))))))))
+      (do_loop
+        (do_statement
+          (loop_control_expression
+            (identifier)
+            (number_literal)
+            (number_literal)
+            (unary_expression
+              (number_literal))))
         (keyword_statement
           (identifier))
         (end_do_loop_statement))
       (end_do_loop_statement
         (block_label)))
-    (do_loop_statement
-      (while_statement
-        (parenthesized_expression
-          (identifier)))
+    (do_loop
+      (do_statement
+        (while_statement
+          (parenthesized_expression
+            (identifier))))
       (assignment_statement
         (identifier)
         (number_literal))
       (end_do_loop_statement))
-    (do_loop_statement
-      (loop_control_expression
-        (identifier)
-        (number_literal)
-        (number_literal))
+    (do_loop
+      (do_statement
+        (loop_control_expression
+          (identifier)
+          (number_literal)
+          (number_literal)))
       (if_statement
         (parenthesized_expression
           (identifier))
@@ -817,32 +823,33 @@ END PROGRAM TEST
     (assignment_statement
       left: (identifier)
       right: (number_literal))
-    (do_loop_statement
-      (concurrent_statement
-        (concurrent_header
-          (concurrent_control
+    (do_loop
+      (do_statement
+        (concurrent_statement
+          (concurrent_header
+            (concurrent_control
+              (identifier)
+              initial: (number_literal)
+              final: (identifier))
+            (concurrent_mask
+              (relational_expression
+                left: (call_expression
+                  (identifier)
+                  (argument_list
+                    (identifier)))
+                right: (number_literal))))
+          (concurrent_locality
+            (identifier))
+          (concurrent_locality
             (identifier)
-            initial: (number_literal)
-            final: (identifier))
-          (concurrent_mask
-            (relational_expression
-              left: (call_expression
-                (identifier)
-                (argument_list
-                  (identifier)))
-              right: (number_literal))))
-        (concurrent_locality
-          (identifier))
-        (concurrent_locality
-          (identifier)
-          (identifier))
-        (concurrent_locality
-          (binary_op)
-          (identifier)
-          (identifier))
-        (concurrent_locality
-          (binary_op)
-          (identifier)))
+            (identifier))
+          (concurrent_locality
+            (binary_op)
+            (identifier)
+            (identifier))
+          (concurrent_locality
+            (binary_op)
+            (identifier))))
       (assignment_statement
         left: (identifier)
         right: (call_expression


### PR DESCRIPTION
Closes #157 

Includes #156 

This change makes it possible to capture the two forms of `do` loops directly from the AST, without needing to do any parsing of the text.