### PR TITLE
fix(cmake): expose wctype functions on BSD systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,15 @@ project(tree-sitter-fortran
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 option(TREE_SITTER_REUSE_ALLOCATOR "Reuse the library allocator" OFF)
 
+# Ensure wide character functions (iswblank, iswxdigit, etc.) are visible
+# when compiling in strict C11 mode on POSIX systems
+if(UNIX)
+    add_compile_definitions(_XOPEN_SOURCE=700)
+    if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD|NetBSD|DragonFly|OpenBSD")
+        add_compile_definitions(_BSD_VISIBLE)
+    endif()
+endif()
+
 set(TREE_SITTER_ABI_VERSION 14 CACHE STRING "Tree-sitter ABI version")
 if(NOT ${TREE_SITTER_ABI_VERSION} MATCHES "^[0-9]+$")
     unset(TREE_SITTER_ABI_VERSION CACHE)


### PR DESCRIPTION
Hi, I encountered a build failure on FreeBSD while attempting to build this grammar for distribution in the Julia ecosystem, https://github.com/JuliaPackaging/Yggdrasil/pull/12689.

This adds `_XOPEN_SOURCE=700` and `_BSD_VISIBLE` definitions to work around BSD header visibility quirks when compiling with `C_STANDARD 11`.

As far as I can tell this appears to be the usual way to handle this.