### PR TITLE
Make default clause in select statements consistent

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1574,7 +1574,10 @@ module.exports = grammar({
             seq('(', field('type', choice($.intrinsic_type, $.identifier)), ')'),
           ),
         ),
-        alias($._class_default, $.default)
+        seq(
+          caseInsensitive('class'),
+          alias(caseInsensitive('default'), $.default)
+        ),
       ),
       optional($._block_label),
       $._end_of_statement,

--- a/grammar.js
+++ b/grammar.js
@@ -1584,9 +1584,6 @@ module.exports = grammar({
       repeat($._statement)
     ),
 
-    // Standalone rule otherwise it gets aliased as '(default) (default)'
-    _class_default: $ => whiteSpacedKeyword('class', 'default', false),
-
     case_value_range_list: $ => commaSep1(choice(
       $._expression,
       $.extent_specifier

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -16954,13 +16954,32 @@
               ]
             },
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_class_default"
-              },
-              "named": true,
-              "value": "default"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[cC][lL][aA][sS][sS]"
+                  },
+                  "named": false,
+                  "value": "class"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[dD][eE][fF][aA][uU][lL][tT]"
+                    },
+                    "named": false,
+                    "value": "default"
+                  },
+                  "named": true,
+                  "value": "default"
+                }
+              ]
             }
           ]
         },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -17008,28 +17008,6 @@
         }
       ]
     },
-    "_class_default": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "PATTERN",
-              "value": "[cC][lL][aA][sS][sS]"
-            },
-            {
-              "type": "PATTERN",
-              "value": "[dD][eE][fF][aA][uU][lL][tT]"
-            }
-          ]
-        },
-        {
-          "type": "PATTERN",
-          "value": "[cC][lL][aA][sS][sS][dD][eE][fF][aA][uU][lL][tT]"
-        }
-      ]
-    },
     "case_value_range_list": {
       "type": "SEQ",
       "members": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1935,11 +1935,6 @@
     }
   },
   {
-    "type": "default",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "defined_io_procedure",
     "named": true,
     "fields": {}
@@ -7309,6 +7304,10 @@
   {
     "type": "deallocate",
     "named": false
+  },
+  {
+    "type": "default",
+    "named": true
   },
   {
     "type": "default",


### PR DESCRIPTION
Change the default clause for select type statements to make it consistent with the select case statements.

Generated nodes for the two cases are:

 case_statement
   "case"
   default `default`

 type_statement
   "class"
   default `default`