### PR TITLE
Derived type procedure, generic and final statements

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -798,16 +798,16 @@ module.exports = grammar({
       )),
       optional('::'),
       commaSep1(field('declarator', choice(
-        $.method_name,
+        $._method_name,
         $.binding,
       ))),
     ),
-    binding: $ => seq($.binding_name, '=>', $.method_name),
+    binding: $ => seq($.binding_name, '=>', $._method_name),
     binding_name: $ => choice(
       $.identifier,
       $._generic_procedure
     ),
-    method_name: $ => alias($.identifier, 'method_name'),
+    _method_name: $ => alias($.identifier, $.method_name),
 
     procedure_kind: $ => choice(
       caseInsensitive('generic'),

--- a/grammar.js
+++ b/grammar.js
@@ -110,6 +110,7 @@ module.exports = grammar({
     $._expression,
     $._statements,
     $._argument_item,
+    $._procedure_binding,
   ],
 
   rules: {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -22701,7 +22701,8 @@
     "_specification_parts",
     "_expression",
     "_statements",
-    "_argument_item"
+    "_argument_item",
+    "_procedure_binding"
   ],
   "reserved": {}
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -11789,7 +11789,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "method_name"
+                    "name": "_method_name"
                   },
                   {
                     "type": "SYMBOL",
@@ -11815,7 +11815,7 @@
                       "members": [
                         {
                           "type": "SYMBOL",
-                          "name": "method_name"
+                          "name": "_method_name"
                         },
                         {
                           "type": "SYMBOL",
@@ -11844,7 +11844,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "method_name"
+          "name": "_method_name"
         }
       ]
     },
@@ -11861,13 +11861,13 @@
         }
       ]
     },
-    "method_name": {
+    "_method_name": {
       "type": "ALIAS",
       "content": {
         "type": "SYMBOL",
         "name": "identifier"
       },
-      "named": false,
+      "named": true,
       "value": "method_name"
     },
     "procedure_kind": {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4983,7 +4983,7 @@
             "type": "REPEAT",
             "content": {
               "type": "SYMBOL",
-              "name": "procedure_statement"
+              "name": "_procedure_binding"
             }
           },
           {
@@ -5125,7 +5125,7 @@
             "type": "REPEAT",
             "content": {
               "type": "SYMBOL",
-              "name": "procedure_statement"
+              "name": "_procedure_binding"
             }
           },
           {
@@ -5245,7 +5245,7 @@
             "type": "REPEAT",
             "content": {
               "type": "SYMBOL",
-              "name": "procedure_statement"
+              "name": "_procedure_binding"
             }
           }
         ]
@@ -5303,7 +5303,7 @@
             "type": "REPEAT",
             "content": {
               "type": "SYMBOL",
-              "name": "procedure_statement"
+              "name": "_procedure_binding"
             }
           },
           {
@@ -5415,7 +5415,7 @@
             "type": "REPEAT",
             "content": {
               "type": "SYMBOL",
-              "name": "procedure_statement"
+              "name": "_procedure_binding"
             }
           },
           {
@@ -11658,7 +11658,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "procedure_statement"
+                "name": "_procedure_binding"
               },
               {
                 "type": "SYMBOL",
@@ -11684,6 +11684,23 @@
               }
             ]
           }
+        }
+      ]
+    },
+    "_procedure_binding": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "procedure_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "generic_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "final_statement"
         }
       ]
     },
@@ -11831,6 +11848,108 @@
         }
       ]
     },
+    "generic_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[gG][eE][nN][eE][rR][iI][cC]"
+          },
+          "named": false,
+          "value": "generic"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "PREC_LEFT",
+                  "value": 0,
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "access_specifier"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "::"
+        },
+        {
+          "type": "FIELD",
+          "name": "declarator",
+          "content": {
+            "type": "SYMBOL",
+            "name": "binding_list"
+          }
+        }
+      ]
+    },
+    "final_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[fF][iI][nN][aA][lL]"
+          },
+          "named": false,
+          "value": "final"
+        },
+        {
+          "type": "STRING",
+          "value": "::"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "declarator",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_method_name"
+              }
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "declarator",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_method_name"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
     "binding": {
       "type": "SEQ",
       "members": [
@@ -11861,6 +11980,44 @@
         }
       ]
     },
+    "binding_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "binding_name"
+        },
+        {
+          "type": "STRING",
+          "value": "=>"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_method_name"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_method_name"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
     "_method_name": {
       "type": "ALIAS",
       "content": {
@@ -11873,15 +12030,6 @@
     "procedure_kind": {
       "type": "CHOICE",
       "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[gG][eE][nN][eE][rR][iI][cC]"
-          },
-          "named": false,
-          "value": "generic"
-        },
         {
           "type": "ALIAS",
           "content": {
@@ -11931,15 +12079,6 @@
           },
           "named": false,
           "value": "property"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[fF][iI][nN][aA][lL]"
-          },
-          "named": false,
-          "value": "final"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -864,6 +864,25 @@
     }
   },
   {
+    "type": "binding_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "binding_name",
+          "named": true
+        },
+        {
+          "type": "method_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "binding_name",
     "named": true,
     "fields": {},
@@ -2097,6 +2116,14 @@
           "named": true
         },
         {
+          "type": "final_statement",
+          "named": true
+        },
+        {
+          "type": "generic_statement",
+          "named": true
+        },
+        {
           "type": "include_statement",
           "named": true
         },
@@ -2988,6 +3015,22 @@
     }
   },
   {
+    "type": "final_statement",
+    "named": true,
+    "fields": {
+      "declarator": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "method_name",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "forall_statement",
     "named": true,
     "fields": {},
@@ -3255,6 +3298,32 @@
         },
         {
           "type": "procedure_qualifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "generic_statement",
+    "named": true,
+    "fields": {
+      "declarator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "binding_list",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "access_specifier",
           "named": true
         }
       ]
@@ -4585,7 +4654,15 @@
           "named": true
         },
         {
+          "type": "final_statement",
+          "named": true
+        },
+        {
           "type": "function",
+          "named": true
+        },
+        {
+          "type": "generic_statement",
           "named": true
         },
         {
@@ -4725,7 +4802,15 @@
           "named": true
         },
         {
+          "type": "final_statement",
+          "named": true
+        },
+        {
           "type": "function",
+          "named": true
+        },
+        {
+          "type": "generic_statement",
           "named": true
         },
         {
@@ -4836,7 +4921,15 @@
           "named": true
         },
         {
+          "type": "final_statement",
+          "named": true
+        },
+        {
           "type": "function",
+          "named": true
+        },
+        {
+          "type": "generic_statement",
           "named": true
         },
         {
@@ -5040,7 +5133,15 @@
           "named": true
         },
         {
+          "type": "final_statement",
+          "named": true
+        },
+        {
           "type": "function",
+          "named": true
+        },
+        {
+          "type": "generic_statement",
           "named": true
         },
         {
@@ -5180,7 +5281,15 @@
           "named": true
         },
         {
+          "type": "final_statement",
+          "named": true
+        },
+        {
           "type": "function",
+          "named": true
+        },
+        {
+          "type": "generic_statement",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -108,6 +108,24 @@
     ]
   },
   {
+    "type": "_procedure_binding",
+    "named": true,
+    "subtypes": [
+      {
+        "type": "final_statement",
+        "named": true
+      },
+      {
+        "type": "generic_statement",
+        "named": true
+      },
+      {
+        "type": "procedure_statement",
+        "named": true
+      }
+    ]
+  },
+  {
     "type": "_specification_parts",
     "named": true,
     "subtypes": [
@@ -2112,15 +2130,11 @@
       "required": true,
       "types": [
         {
+          "type": "_procedure_binding",
+          "named": true
+        },
+        {
           "type": "contains_statement",
-          "named": true
-        },
-        {
-          "type": "final_statement",
-          "named": true
-        },
-        {
-          "type": "generic_statement",
           "named": true
         },
         {
@@ -2137,10 +2151,6 @@
         },
         {
           "type": "private_statement",
-          "named": true
-        },
-        {
-          "type": "procedure_statement",
           "named": true
         }
       ]
@@ -4634,6 +4644,10 @@
       "required": false,
       "types": [
         {
+          "type": "_procedure_binding",
+          "named": true
+        },
+        {
           "type": "_specification_parts",
           "named": true
         },
@@ -4654,15 +4668,7 @@
           "named": true
         },
         {
-          "type": "final_statement",
-          "named": true
-        },
-        {
           "type": "function",
-          "named": true
-        },
-        {
-          "type": "generic_statement",
           "named": true
         },
         {
@@ -4711,10 +4717,6 @@
         },
         {
           "type": "preproc_include",
-          "named": true
-        },
-        {
-          "type": "procedure_statement",
           "named": true
         },
         {
@@ -4782,6 +4784,10 @@
       "required": false,
       "types": [
         {
+          "type": "_procedure_binding",
+          "named": true
+        },
+        {
           "type": "_specification_parts",
           "named": true
         },
@@ -4802,15 +4808,7 @@
           "named": true
         },
         {
-          "type": "final_statement",
-          "named": true
-        },
-        {
           "type": "function",
-          "named": true
-        },
-        {
-          "type": "generic_statement",
           "named": true
         },
         {
@@ -4859,10 +4857,6 @@
         },
         {
           "type": "preproc_include",
-          "named": true
-        },
-        {
-          "type": "procedure_statement",
           "named": true
         },
         {
@@ -4901,6 +4895,10 @@
       "required": false,
       "types": [
         {
+          "type": "_procedure_binding",
+          "named": true
+        },
+        {
           "type": "_specification_parts",
           "named": true
         },
@@ -4921,15 +4919,7 @@
           "named": true
         },
         {
-          "type": "final_statement",
-          "named": true
-        },
-        {
           "type": "function",
-          "named": true
-        },
-        {
-          "type": "generic_statement",
           "named": true
         },
         {
@@ -4978,10 +4968,6 @@
         },
         {
           "type": "preproc_include",
-          "named": true
-        },
-        {
-          "type": "procedure_statement",
           "named": true
         },
         {
@@ -5113,6 +5099,10 @@
       "required": false,
       "types": [
         {
+          "type": "_procedure_binding",
+          "named": true
+        },
+        {
           "type": "_specification_parts",
           "named": true
         },
@@ -5133,15 +5123,7 @@
           "named": true
         },
         {
-          "type": "final_statement",
-          "named": true
-        },
-        {
           "type": "function",
-          "named": true
-        },
-        {
-          "type": "generic_statement",
           "named": true
         },
         {
@@ -5190,10 +5172,6 @@
         },
         {
           "type": "preproc_include",
-          "named": true
-        },
-        {
-          "type": "procedure_statement",
           "named": true
         },
         {
@@ -5261,6 +5239,10 @@
       "required": false,
       "types": [
         {
+          "type": "_procedure_binding",
+          "named": true
+        },
+        {
           "type": "_specification_parts",
           "named": true
         },
@@ -5281,15 +5263,7 @@
           "named": true
         },
         {
-          "type": "final_statement",
-          "named": true
-        },
-        {
           "type": "function",
-          "named": true
-        },
-        {
-          "type": "generic_statement",
           "named": true
         },
         {
@@ -5338,10 +5312,6 @@
         },
         {
           "type": "preproc_include",
-          "named": true
-        },
-        {
-          "type": "procedure_statement",
           "named": true
         },
         {

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -821,7 +821,7 @@ program test
        procedure, nopass, non_overridable :: static_method ! static method
        procedure instance_method ! instance method
        procedure, public, pass(self) :: pass_method
-       generic, pass :: binding_name => method_name, method_name2
+       generic :: binding_name => method_name, method_name2
        generic, private :: assignment(=) => assign_method
        generic, private :: operator(+) => add_method
        procedure :: one, two => three
@@ -900,25 +900,21 @@ end program
           (procedure_attribute
             (identifier))
           (method_name))
-        (procedure_statement
-          (procedure_kind)
-          (procedure_attribute)
-          (binding
+        (generic_statement
+          (binding_list
             (binding_name
               (identifier))
-            (method_name))
-          (method_name))
-        (procedure_statement
-          (procedure_kind)
-          (procedure_attribute)
-          (binding
+            (method_name)
+            (method_name)))
+        (generic_statement
+          (access_specifier)
+          (binding_list
             (binding_name
               (assignment))
             (method_name)))
-        (procedure_statement
-          (procedure_kind)
-          (procedure_attribute)
-          (binding
+        (generic_statement
+          (access_specifier)
+          (binding_list
             (binding_name
               (operator
                 (operator_name)))
@@ -930,8 +926,7 @@ end program
             (binding_name
               (identifier))
             (method_name)))
-        (procedure_statement
-          (procedure_kind)
+        (final_statement
           (method_name)))
       (end_type_statement
         (name)))

--- a/test/corpus/preprocessor.txt
+++ b/test/corpus/preprocessor.txt
@@ -508,8 +508,7 @@ end module foo
         (contains_statement)
         (preproc_if
           (identifier)
-          (procedure_statement
-            (procedure_kind)
+          (final_statement
             (method_name))))
       (end_type_statement
         (name)))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -2440,10 +2440,9 @@ end module
       (derived_type_procedures
         (contains_statement)
         (comment)
-        (procedure_statement
-          (procedure_kind)
-          (procedure_attribute)
-          (binding
+        (generic_statement
+          (access_specifier)
+          (binding_list
             (binding_name
               (defined_io_procedure))
             (method_name)))


### PR DESCRIPTION
Add extra rules for generic and final statements

Both variants do not fit into the general rule procedure_statement
used in derived type definitions. Both, procedure attributes (on
left side of ::), and binding structure (on the side of ::) differ
compared to procedure statements.
