### PR TITLE
Do label block

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -61,9 +61,9 @@ module.exports = grammar({
     $._external_end_of_statement,
     $._preproc_unary_operator,
     $.hollerith_constant,
-    $.do_label,
+    $._do_label,
     $.do_label_virtual,
-    $.do_label_continue,
+    $._do_label_continue,
   ],
 
   extras: $ => [
@@ -1319,7 +1319,7 @@ module.exports = grammar({
     // old style labeled loop
     do_stmt_label: $ => seq(
       caseInsensitive('do'),
-      field('do_label', optional($.do_label)),
+      field('do_label', optional(alias($._do_label, $.statement_label_reference))),
       optional($._do_stmt_control)
     ),
 
@@ -1357,9 +1357,9 @@ module.exports = grammar({
     end_do_label_loop_statement: $ => choice(
       field('do_label', $.do_label_virtual),
       seq(
-        field('do_label', $.do_label_continue),
+        field('do_label', alias($._do_label_continue, $.statement_label)),
         choice(
-            caseInsensitive('continue'),
+            $._statements,
             whiteSpacedKeyword('end', 'do')
         )
       )

--- a/grammar.js
+++ b/grammar.js
@@ -1293,9 +1293,9 @@ module.exports = grammar({
     ),
     _signed_literal: $ => prec.right(PREC.UNARY, seq(choice('-', '+'), $.number_literal)),
 
-    // old-style labeled do loop does not allow a block label, however, the rule
-    // accepts a labeled do with an additional block label,
-    // hence three structures to match:
+    // old-style labeled do loop does allow a block label (do-construct-name),
+    // but it seems a bit wild and may never have been used in practice
+    // * block_label: do-label     (double-labeled loop, old style)
     // *              do label     (labeled loop, old style)
     // * block_label: do           (nonlabeled loop)
     // *              do           (nonlabeled loop)
@@ -1309,9 +1309,15 @@ module.exports = grammar({
 
     // choice between labeled and nonlabeled do
     _do_stmt: $ => choice(
-      alias($.do_stmt_label, $.do_statement),
       seq(
-        $.block_label_start_expression,
+        // theoretically permitted, but useful to include?
+        optional($.block_label_start_expression),
+        alias($.do_stmt_label, $.do_statement)
+      ),
+      // or without block_label
+      // alias($.do_stmt_label, $.do_statement),
+      seq(
+        optional($.block_label_start_expression),
         alias($.do_stmt_nonlabel, $.do_statement)
       )
     ),
@@ -1319,7 +1325,7 @@ module.exports = grammar({
     // old style labeled loop
     do_stmt_label: $ => seq(
       caseInsensitive('do'),
-      field('do_label', optional(alias($._do_label, $.statement_label_reference))),
+      field('do_label', alias($._do_label, $.statement_label_reference)),
       optional($._do_stmt_control)
     ),
 
@@ -1341,6 +1347,9 @@ module.exports = grammar({
       ),
     ),
 
+    // choice between old-style and new-style end do,
+    // the external scanner tokens for old-style loops
+    // ensure that only the matching end_do rule is accepted
     _end_do_loop: $ => choice(
       $.end_do_label_loop_statement,
       seq(
@@ -1359,8 +1368,13 @@ module.exports = grammar({
       seq(
         field('do_label', alias($._do_label_continue, $.statement_label)),
         choice(
-            $._statements,
-            whiteSpacedKeyword('end', 'do')
+          $._statements,
+          seq(
+            whiteSpacedKeyword('end', 'do'),
+            optional($._block_label)
+          )
+          // or without block_label
+          //whiteSpacedKeyword('end', 'do'),
         )
       )
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -61,6 +61,9 @@ module.exports = grammar({
     $._external_end_of_statement,
     $._preproc_unary_operator,
     $.hollerith_constant,
+    $.do_label,
+    $.do_label_virtual,
+    $.do_label_continue,
   ],
 
   extras: $ => [
@@ -1154,8 +1157,6 @@ module.exports = grammar({
       $.select_type_statement,
       $.select_rank_statement,
       $.do_loop,
-      $.do_label_statement,
-      $.end_do_label_statement,
       $.format_statement,
       $.open_statement,
       $.close_statement,
@@ -1292,47 +1293,83 @@ module.exports = grammar({
     ),
     _signed_literal: $ => prec.right(PREC.UNARY, seq(choice('-', '+'), $.number_literal)),
 
+    // old-style labeled do loop does not allow a block label, however, the rule
+    // accepts a labeled do with an additional block label,
+    // hence three structures to match:
+    // *              do label     (labeled loop, old style)
+    // * block_label: do           (nonlabeled loop)
+    // *              do           (nonlabeled loop)
+
     do_loop: $ => seq(
-      optional($.block_label_start_expression),
-      $.do_statement,
+      $._do_stmt,
       $._end_of_statement,
       repeat($._statement),
-      optional($.statement_label),
-      $.end_do_loop_statement
+      $._end_do_loop
     ),
 
-    do_statement: $ => seq(
+    // choice between labeled and nonlabeled do
+    _do_stmt: $ => choice(
+      alias($.do_stmt_label, $.do_statement),
+      seq(
+        $.block_label_start_expression,
+        alias($.do_stmt_nonlabel, $.do_statement)
+      )
+    ),
+
+    // old style labeled loop
+    do_stmt_label: $ => seq(
       caseInsensitive('do'),
+      field('do_label', optional($.do_label)),
+      optional($._do_stmt_control)
+    ),
+
+    // new style loop (the optional block name is matched outside, as
+    // it should not be part of this node)
+    do_stmt_nonlabel: $ => seq(
+      caseInsensitive('do'),
+      optional($._do_stmt_control)
+    ),
+
+    // control part of the do statement (after [name:] do [label])
+    // (corresponds to "loop-control" in the F23 standard)
+    _do_stmt_control: $ => seq(
       optional(','),
-      optional(choice(
+      choice(
         $.while_statement,
         $.loop_control_expression,
         $.concurrent_statement
-      )),
+      ),
     ),
 
+    _end_do_loop: $ => choice(
+      $.end_do_label_loop_statement,
+      seq(
+        optional($.statement_label),
+        $.end_do_loop_statement
+      )
+    ),
+
+    // end statement for old style do loop, there is one continue
+    // statement which might close several loops, the last one has a
+    // do_label_continue, the inner loops get a do_label_virtual, the
+    // innermost loop consumes the label at the start of the line, the
+    // outermost loop gets "continue" or "end do" keywords
+    end_do_label_loop_statement: $ => choice(
+      field('do_label', $.do_label_virtual),
+      seq(
+        field('do_label', $.do_label_continue),
+        choice(
+            caseInsensitive('continue'),
+            whiteSpacedKeyword('end', 'do')
+        )
+      )
+    ),
+
+    // new style do loop, allows statement label as well as block label
     end_do_loop_statement: $ => seq(
       whiteSpacedKeyword('end', 'do'),
       optional($._block_label)
     ),
-
-    // Deleted feature: non-block `do`. Actually, labelled-do is still
-    // valid (but obsolescent), but we need to capture them separately
-    // because otherwise it's too had to capture them at all
-    do_label_statement: $ => seq(
-      caseInsensitive('do'),
-      $.statement_label_reference,
-      optional(','),
-      $.loop_control_expression
-    ),
-
-    // Because we've lumped together labelled-do and non-block-do in
-    // `do_label_statement`, we also need to be able to capture `end
-    // do` for a labelled-do
-    end_do_label_statement: $ => prec(-1, seq(
-      $.statement_label,
-      whiteSpacedKeyword('end', 'do'),
-    )),
 
     while_statement: $ => seq(caseInsensitive('while'),
       $.parenthesized_expression),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -15088,8 +15088,13 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "do_label"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_do_label"
+                },
+                "named": true,
+                "value": "statement_label_reference"
               },
               {
                 "type": "BLANK"
@@ -15219,21 +15224,21 @@
               "type": "FIELD",
               "name": "do_label",
               "content": {
-                "type": "SYMBOL",
-                "name": "do_label_continue"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_do_label_continue"
+                },
+                "named": true,
+                "value": "statement_label"
               }
             },
             {
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[cC][oO][nN][tT][iI][nN][uU][eE]"
-                  },
-                  "named": false,
-                  "value": "continue"
+                  "type": "SYMBOL",
+                  "name": "_statements"
                 },
                 {
                   "type": "CHOICE",
@@ -22768,7 +22773,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "do_label"
+      "name": "_do_label"
     },
     {
       "type": "SYMBOL",
@@ -22776,7 +22781,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "do_label_continue"
+      "name": "_do_label_continue"
     }
   ],
   "inline": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -14056,14 +14056,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "do_label_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "end_do_label_statement"
-        },
-        {
-          "type": "SYMBOL",
           "name": "format_statement"
         },
         {
@@ -15025,20 +15017,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "block_label_start_expression"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
           "type": "SYMBOL",
-          "name": "do_statement"
+          "name": "_do_stmt"
         },
         {
           "type": "SYMBOL",
@@ -15052,24 +15032,44 @@
           }
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "statement_label"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
           "type": "SYMBOL",
-          "name": "end_do_loop_statement"
+          "name": "_end_do_loop"
         }
       ]
     },
-    "do_statement": {
+    "_do_stmt": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "do_stmt_label"
+          },
+          "named": true,
+          "value": "do_statement"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "block_label_start_expression"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "do_stmt_nonlabel"
+              },
+              "named": true,
+              "value": "do_statement"
+            }
+          ]
+        }
+      ]
+    },
+    "do_stmt_label": {
       "type": "SEQ",
       "members": [
         {
@@ -15081,6 +15081,65 @@
           "named": false,
           "value": "do"
         },
+        {
+          "type": "FIELD",
+          "name": "do_label",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "do_label"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_do_stmt_control"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "do_stmt_nonlabel": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[dD][oO]"
+          },
+          "named": false,
+          "value": "do"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_do_stmt_control"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_do_stmt_control": {
+      "type": "SEQ",
+      "members": [
         {
           "type": "CHOICE",
           "members": [
@@ -15097,24 +15156,123 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "SYMBOL",
+              "name": "while_statement"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "loop_control_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "concurrent_statement"
+            }
+          ]
+        }
+      ]
+    },
+    "_end_do_loop": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "end_do_label_loop_statement"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
               "type": "CHOICE",
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "while_statement"
+                  "name": "statement_label"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "loop_control_expression"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "concurrent_statement"
+                  "type": "BLANK"
                 }
               ]
             },
             {
-              "type": "BLANK"
+              "type": "SYMBOL",
+              "name": "end_do_loop_statement"
+            }
+          ]
+        }
+      ]
+    },
+    "end_do_label_loop_statement": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "do_label",
+          "content": {
+            "type": "SYMBOL",
+            "name": "do_label_virtual"
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "do_label",
+              "content": {
+                "type": "SYMBOL",
+                "name": "do_label_continue"
+              }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[cC][oO][nN][tT][iI][nN][uU][eE]"
+                  },
+                  "named": false,
+                  "value": "continue"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "PATTERN",
+                            "value": "[eE][nN][dD]"
+                          },
+                          "named": false,
+                          "value": "end"
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "PATTERN",
+                            "value": "[dD][oO]"
+                          },
+                          "named": false,
+                          "value": "do"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[eE][nN][dD][dD][oO]"
+                      },
+                      "named": false,
+                      "value": "enddo"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
@@ -15173,90 +15331,6 @@
           ]
         }
       ]
-    },
-    "do_label_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[dD][oO]"
-          },
-          "named": false,
-          "value": "do"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "statement_label_reference"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "loop_control_expression"
-        }
-      ]
-    },
-    "end_do_label_statement": {
-      "type": "PREC",
-      "value": -1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "statement_label"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
-                    },
-                    "named": false,
-                    "value": "end"
-                  },
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[dD][oO]"
-                    },
-                    "named": false,
-                    "value": "do"
-                  }
-                ]
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[eE][nN][dD][dD][oO]"
-                },
-                "named": false,
-                "value": "enddo"
-              }
-            ]
-          }
-        ]
-      }
     },
     "while_statement": {
       "type": "SEQ",
@@ -22691,6 +22765,18 @@
     {
       "type": "SYMBOL",
       "name": "hollerith_constant"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "do_label"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "do_label_virtual"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "do_label_continue"
     }
   ],
   "inline": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -15041,20 +15041,45 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "do_stmt_label"
-          },
-          "named": true,
-          "value": "do_statement"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "block_label_start_expression"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "do_stmt_label"
+              },
+              "named": true,
+              "value": "do_statement"
+            }
+          ]
         },
         {
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "block_label_start_expression"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "block_label_start_expression"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
               "type": "ALIAS",
@@ -15085,21 +15110,13 @@
           "type": "FIELD",
           "name": "do_label",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_do_label"
-                },
-                "named": true,
-                "value": "statement_label_reference"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_do_label"
+            },
+            "named": true,
+            "value": "statement_label_reference"
           }
         },
         {
@@ -15241,39 +15258,56 @@
                   "name": "_statements"
                 },
                 {
-                  "type": "CHOICE",
+                  "type": "SEQ",
                   "members": [
                     {
-                      "type": "SEQ",
+                      "type": "CHOICE",
                       "members": [
                         {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "PATTERN",
-                            "value": "[eE][nN][dD]"
-                          },
-                          "named": false,
-                          "value": "end"
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "ALIAS",
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "[eE][nN][dD]"
+                              },
+                              "named": false,
+                              "value": "end"
+                            },
+                            {
+                              "type": "ALIAS",
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "[dD][oO]"
+                              },
+                              "named": false,
+                              "value": "do"
+                            }
+                          ]
                         },
                         {
                           "type": "ALIAS",
                           "content": {
                             "type": "PATTERN",
-                            "value": "[dD][oO]"
+                            "value": "[eE][nN][dD][dD][oO]"
                           },
                           "named": false,
-                          "value": "do"
+                          "value": "enddo"
                         }
                       ]
                     },
                     {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "[eE][nN][dD][dD][oO]"
-                      },
-                      "named": false,
-                      "value": "enddo"
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_block_label"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
                     }
                   ]
                 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2268,7 +2268,7 @@
         "required": false,
         "types": [
           {
-            "type": "do_label",
+            "type": "statement_label_reference",
             "named": true
           }
         ]
@@ -2535,15 +2535,25 @@
         "required": true,
         "types": [
           {
-            "type": "do_label_continue",
+            "type": "do_label_virtual",
             "named": true
           },
           {
-            "type": "do_label_virtual",
+            "type": "statement_label",
             "named": true
           }
         ]
       }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "_statements",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -7404,14 +7414,6 @@
   {
     "type": "do",
     "named": false
-  },
-  {
-    "type": "do_label",
-    "named": true
-  },
-  {
-    "type": "do_label_continue",
-    "named": true
   },
   {
     "type": "do_label_virtual",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2552,6 +2552,10 @@
         {
           "type": "_statements",
           "named": true
+        },
+        {
+          "type": "block_label",
+          "named": true
         }
       ]
     }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -264,15 +264,7 @@
         "named": true
       },
       {
-        "type": "do_label_statement",
-        "named": true
-      },
-      {
         "type": "do_loop",
-        "named": true
-      },
-      {
-        "type": "end_do_label_statement",
         "named": true
       },
       {
@@ -2209,25 +2201,6 @@
     }
   },
   {
-    "type": "do_label_statement",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "loop_control_expression",
-          "named": true
-        },
-        {
-          "type": "statement_label_reference",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "do_loop",
     "named": true,
     "fields": {},
@@ -2245,6 +2218,10 @@
         },
         {
           "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "end_do_label_loop_statement",
           "named": true
         },
         {
@@ -2285,7 +2262,18 @@
   {
     "type": "do_statement",
     "named": true,
-    "fields": {},
+    "fields": {
+      "do_label": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "do_label",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": false,
       "required": false,
@@ -2539,18 +2527,23 @@
     }
   },
   {
-    "type": "end_do_label_statement",
+    "type": "end_do_label_loop_statement",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "statement_label",
-          "named": true
-        }
-      ]
+    "fields": {
+      "do_label": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "do_label_continue",
+            "named": true
+          },
+          {
+            "type": "do_label_virtual",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -7411,6 +7404,18 @@
   {
     "type": "do",
     "named": false
+  },
+  {
+    "type": "do_label",
+    "named": true
+  },
+  {
+    "type": "do_label_continue",
+    "named": true
+  },
+  {
+    "type": "do_label_virtual",
+    "named": true
   },
   {
     "type": "double",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -30,29 +30,29 @@ static bool is_identifier_char(char chr) { return iswalnum(chr) || chr == '_'; }
 
 static bool is_boz_sentinel(char chr) {
     switch (chr) {
-        case 'B':
-        case 'b':
-        case 'O':
-        case 'o':
-        case 'Z':
-        case 'z':
-            return true;
-        default:
-            return false;
+    case 'B':
+    case 'b':
+    case 'O':
+    case 'o':
+    case 'Z':
+    case 'z':
+        return true;
+    default:
+        return false;
     }
 }
 
 static bool is_exp_sentinel(char chr) {
     switch (chr) {
-        case 'D':
-        case 'd':
-        case 'E':
-        case 'e':
-        case 'Q':
-        case 'q':
-            return true;
-        default:
-            return false;
+    case 'D':
+    case 'd':
+    case 'E':
+    case 'e':
+    case 'Q':
+    case 'q':
+        return true;
+    default:
+        return false;
     }
 }
 
@@ -68,17 +68,17 @@ static bool scan_int(TSLexer *lexer) {
 
     // handle line continuations
     if (lexer->lookahead == '&') {
-      advance(lexer);
-      while (iswspace(lexer->lookahead)) {
         advance(lexer);
-      }
-      // second '&' required to continue the literal
-      if (lexer->lookahead == '&') {
-        advance(lexer);
-        // don't return here, as we may have finished literal on first
-        // line but still have second '&'
-        scan_int(lexer);
-      }
+        while (iswspace(lexer->lookahead)) {
+            advance(lexer);
+        }
+        // second '&' required to continue the literal
+        if (lexer->lookahead == '&') {
+            advance(lexer);
+            // don't return here, as we may have finished literal on first
+            // line but still have second '&'
+            scan_int(lexer);
+        }
     }
 
     return true;
@@ -290,31 +290,31 @@ static bool scan_end_line_continuation(Scanner *scanner, TSLexer *lexer) {
 }
 
 static bool scan_string_literal_kind(TSLexer *lexer) {
-  // Strictly, it's allowed for the kind to be an integer literal, in
-  // practice I've not seen it
-  if (!iswalpha(lexer->lookahead)) {
-    return false;
-  }
+    // Strictly, it's allowed for the kind to be an integer literal, in
+    // practice I've not seen it
+    if (!iswalpha(lexer->lookahead)) {
+        return false;
+    }
 
-  lexer->result_symbol = STRING_LITERAL_KIND;
+    lexer->result_symbol = STRING_LITERAL_KIND;
 
-  // We need two characters of lookahead to see `_"`
-  char current_char = '\0';
+    // We need two characters of lookahead to see `_"`
+    char current_char = '\0';
 
-  while (is_identifier_char(lexer->lookahead) && !lexer->eof(lexer)) {
-      current_char = lexer->lookahead;
-      // Don't capture the trailing underscore as part of the kind identifier
-      if (lexer->lookahead == '_') {
-          lexer->mark_end(lexer);
-      }
-      advance(lexer);
-  }
+    while (is_identifier_char(lexer->lookahead) && !lexer->eof(lexer)) {
+        current_char = lexer->lookahead;
+        // Don't capture the trailing underscore as part of the kind identifier
+        if (lexer->lookahead == '_') {
+            lexer->mark_end(lexer);
+        }
+        advance(lexer);
+    }
 
-  if ((current_char != '_') || (lexer->lookahead != '"' && lexer->lookahead != '\'')) {
-    return false;
-  }
+    if ((current_char != '_') || (lexer->lookahead != '"' && lexer->lookahead != '\'')) {
+        return false;
+    }
 
-  return true;
+    return true;
 }
 
 static bool scan_string_literal(TSLexer *lexer) {
@@ -384,13 +384,13 @@ static bool scan_string_literal(TSLexer *lexer) {
 
 /// Need an external scanner to catch '!' before its parsed as a comment
 static bool scan_preproc_unary_operator(TSLexer *lexer) {
-  const char next_char = lexer->lookahead;
-  if (next_char == '!' || next_char == '~' || next_char == '-' || next_char == '+') {
-    advance(lexer);
-    lexer->result_symbol = PREPROC_UNARY_OPERATOR;
-    return true;
-  }
-  return false;
+    const char next_char = lexer->lookahead;
+    if (next_char == '!' || next_char == '~' || next_char == '-' || next_char == '+') {
+        advance(lexer);
+        lexer->result_symbol = PREPROC_UNARY_OPERATOR;
+        return true;
+    }
+    return false;
 }
 
 static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
@@ -442,9 +442,9 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
     }
 
     if (valid_symbols[PREPROC_UNARY_OPERATOR]) {
-      if (scan_preproc_unary_operator(lexer)) {
-        return true;
-      }
+        if (scan_preproc_unary_operator(lexer)) {
+            return true;
+        }
     }
 
     if (scan_start_line_continuation(scanner, lexer)) {
@@ -452,11 +452,11 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
     }
 
     if (valid_symbols[STRING_LITERAL_KIND]) {
-      // This may need a lot of lookahead, so should (probably) always
-      // be the last token to look for
-      if (scan_string_literal_kind(lexer)) {
-        return true;
-      }
+        // This may need a lot of lookahead, so should (probably) always
+        // be the last token to look for
+        if (scan_string_literal_kind(lexer)) {
+            return true;
+        }
     }
 
     return false;

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -905,6 +905,9 @@ program test
           A(i,j) = A(i,j) + B(k,l,m)
 200 Continue
 100 End Do
+
+    do 300 i = 1,10
+300 A(i) = i
 end program test
 
 --------------------------------------------------------------------------------
@@ -915,14 +918,14 @@ end program test
       (name))
     (do_loop
       (do_statement
-        (do_label)
+        (statement_label_reference)
         (loop_control_expression
           (identifier)
           (number_literal)
           (number_literal)))
       (do_loop
         (do_statement
-          (do_label)
+          (statement_label_reference)
           (loop_control_expression
             (identifier)
             (number_literal)
@@ -939,10 +942,11 @@ end program test
         (end_do_label_loop_statement
           (do_label_virtual)))
       (end_do_label_loop_statement
-        (do_label_continue)))
+        (statement_label)
+        (keyword_statement)))
     (do_loop
       (do_statement
-        (do_label)
+        (statement_label_reference)
         (loop_control_expression
           (identifier)
           (number_literal)
@@ -954,38 +958,38 @@ end program test
             (identifier)))
         (identifier))
       (end_do_label_loop_statement
-        (do_label_continue)))
+        (statement_label)))
     (do_loop
       (do_statement
-        (do_label)
+        (statement_label_reference)
         (loop_control_expression
           (identifier)
           (number_literal)
           (number_literal)))
       (do_loop
         (do_statement
-          (do_label)
+          (statement_label_reference)
           (loop_control_expression
             (identifier)
             (number_literal)
             (number_literal)))
         (do_loop
           (do_statement
-            (do_label)
+            (statement_label_reference)
             (loop_control_expression
               (identifier)
               (number_literal)
               (number_literal)))
           (do_loop
             (do_statement
-              (do_label)
+              (statement_label_reference)
               (loop_control_expression
                 (identifier)
                 (number_literal)
                 (number_literal)))
             (do_loop
               (do_statement
-                (do_label)
+                (statement_label_reference)
                 (loop_control_expression
                   (identifier)
                   (number_literal)
@@ -1013,11 +1017,27 @@ end program test
             (end_do_label_loop_statement
               (do_label_virtual)))
           (end_do_label_loop_statement
-            (do_label_continue)))
+            (statement_label)
+            (keyword_statement)))
         (end_do_label_loop_statement
           (do_label_virtual)))
       (end_do_label_loop_statement
-        (do_label_continue)))
+        (statement_label)))
+    (do_loop
+      (do_statement
+        (statement_label_reference)
+        (loop_control_expression
+          (identifier)
+          (number_literal)
+          (number_literal)))
+      (end_do_label_loop_statement
+        (statement_label)
+        (assignment_statement
+          (call_expression
+            (identifier)
+            (argument_list
+              (identifier)))
+          (identifier))))
     (end_program_statement
       (name))))
 

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -908,6 +908,12 @@ program test
 
     do 300 i = 1,10
 300 A(i) = i
+
+    double_loop: do 400, i=1,10
+      inner: do 500, j=1,10
+500   enddo inner
+400 enddo double_loop
+
 end program test
 
 --------------------------------------------------------------------------------
@@ -1038,6 +1044,28 @@ end program test
             (argument_list
               (identifier)))
           (identifier))))
+    (do_loop
+      (block_label_start_expression)
+      (do_statement
+        (statement_label_reference)
+        (loop_control_expression
+          (identifier)
+          (number_literal)
+          (number_literal)))
+      (do_loop
+        (block_label_start_expression)
+        (do_statement
+          (statement_label_reference)
+          (loop_control_expression
+            (identifier)
+            (number_literal)
+            (number_literal)))
+        (end_do_label_loop_statement
+          (statement_label)
+          (block_label)))
+      (end_do_label_loop_statement
+        (statement_label)
+        (block_label)))
     (end_program_statement
       (name))))
 

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -896,6 +896,15 @@ program test
   do 10 i = 1, 10
     bar(i) = i
 10 end do
+
+  do 100 i = 1,10
+    do 100 j = 1,10
+      do 200 k = 1,10
+        do 200 l = 1,10
+          do 200 m = 1,10
+          A(i,j) = A(i,j) + B(k,l,m)
+200 Continue
+100 End Do
 end program test
 
 --------------------------------------------------------------------------------
@@ -904,43 +913,111 @@ end program test
   (program
     (program_statement
       (name))
-    (do_label_statement
-      (statement_label_reference)
-      (loop_control_expression
-        (identifier)
-        (number_literal)
-        (number_literal)))
-    (do_label_statement
-      (statement_label_reference)
-      (loop_control_expression
-        (identifier)
-        (number_literal)
-        (number_literal)))
-    (assignment_statement
-      (call_expression
-        (identifier)
-        (argument_list
+    (do_loop
+      (do_statement
+        (do_label)
+        (loop_control_expression
           (identifier)
-          (identifier)))
-      (math_expression
-        (identifier)
-        (identifier)))
-    (statement_label)
-    (keyword_statement)
-    (do_label_statement
-      (statement_label_reference)
-      (loop_control_expression
-        (identifier)
-        (number_literal)
-        (number_literal)))
-    (assignment_statement
-      (call_expression
-        (identifier)
-        (argument_list
-          (identifier)))
-      (identifier))
-    (end_do_label_statement
-      (statement_label))
+          (number_literal)
+          (number_literal)))
+      (do_loop
+        (do_statement
+          (do_label)
+          (loop_control_expression
+            (identifier)
+            (number_literal)
+            (number_literal)))
+        (assignment_statement
+          (call_expression
+            (identifier)
+            (argument_list
+              (identifier)
+              (identifier)))
+          (math_expression
+            (identifier)
+            (identifier)))
+        (end_do_label_loop_statement
+          (do_label_virtual)))
+      (end_do_label_loop_statement
+        (do_label_continue)))
+    (do_loop
+      (do_statement
+        (do_label)
+        (loop_control_expression
+          (identifier)
+          (number_literal)
+          (number_literal)))
+      (assignment_statement
+        (call_expression
+          (identifier)
+          (argument_list
+            (identifier)))
+        (identifier))
+      (end_do_label_loop_statement
+        (do_label_continue)))
+    (do_loop
+      (do_statement
+        (do_label)
+        (loop_control_expression
+          (identifier)
+          (number_literal)
+          (number_literal)))
+      (do_loop
+        (do_statement
+          (do_label)
+          (loop_control_expression
+            (identifier)
+            (number_literal)
+            (number_literal)))
+        (do_loop
+          (do_statement
+            (do_label)
+            (loop_control_expression
+              (identifier)
+              (number_literal)
+              (number_literal)))
+          (do_loop
+            (do_statement
+              (do_label)
+              (loop_control_expression
+                (identifier)
+                (number_literal)
+                (number_literal)))
+            (do_loop
+              (do_statement
+                (do_label)
+                (loop_control_expression
+                  (identifier)
+                  (number_literal)
+                  (number_literal)))
+              (assignment_statement
+                (call_expression
+                  (identifier)
+                  (argument_list
+                    (identifier)
+                    (identifier)))
+                (math_expression
+                  (call_expression
+                    (identifier)
+                    (argument_list
+                      (identifier)
+                      (identifier)))
+                  (call_expression
+                    (identifier)
+                    (argument_list
+                      (identifier)
+                      (identifier)
+                      (identifier)))))
+              (end_do_label_loop_statement
+                (do_label_virtual)))
+            (end_do_label_loop_statement
+              (do_label_virtual)))
+          (end_do_label_loop_statement
+            (do_label_continue)))
+        (end_do_label_loop_statement
+          (do_label_virtual)))
+      (end_do_label_loop_statement
+        (do_label_continue)))
     (end_program_statement
       (name))))
 


### PR DESCRIPTION
Add three external tokens DO_LABEL, DO_LABEL_VIRTUAL and
DO_LABEL_CONTINUE to discover and track old style do statements like
```
do 123, i = 1,23
   do 123, j = 1,23
      ! code
123 continue
```
in scanner. This yields proper (do_loop ...) nodes also for these old style loops,
and the scope of these loops is properly represented in the tree. For details see 32a25c99450ab2b43592d12450c549ab6453d7d9 and #177.

The first commit makes indentation consistent in src/scanner.c. I went for indentation level 4, as this seemed to be the main level used.