### PR TITLE
Refactor and extend `end` construct parsing

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -305,7 +305,7 @@ module.exports = grammar({
     ),
 
     program_statement: $ => seq(caseInsensitive('program'), $._name, $._end_of_statement),
-    end_program_statement: $ => blockStructureEnding1($, 'program', {labelRule: $._name, eos: false}),
+    end_program_statement: $ => blockStructureEnding1($, 'program', $._name),
 
     module: $ => seq(
       $.module_statement,
@@ -322,7 +322,7 @@ module.exports = grammar({
     ),
 
     module_statement: $ => seq(caseInsensitive('module'), $._name, $._end_of_statement),
-    end_module_statement: $ => blockStructureEnding1($, 'module', {labelRule: $._name, eos: false}),
+    end_module_statement: $ => blockStructureEnding1($, 'module', $._name),
 
     submodule: $ => seq(
       $.submodule_statement,
@@ -349,7 +349,7 @@ module.exports = grammar({
       $._name,
       $._end_of_statement,
     ),
-    end_submodule_statement: $ => blockStructureEnding1($, 'submodule', {labelRule: $._name, eos: false}),
+    end_submodule_statement: $ => blockStructureEnding1($, 'submodule', $._name),
     module_name: $ => $._name,
 
     interface: $ => seq(
@@ -383,7 +383,7 @@ module.exports = grammar({
       $._end_of_statement,
     ),
 
-    end_interface_statement: $ => blockStructureEnding1($, 'interface', {labelRule: $._end_interface_spec, eos: false}),
+    end_interface_statement: $ => blockStructureEnding1($, 'interface', $._end_interface_spec),
 
     _end_interface_spec: $ => choice(
       $._name,
@@ -410,7 +410,7 @@ module.exports = grammar({
       $._end_of_statement
     ),
 
-    end_block_data_statement: $ => blockStructureEnding2($, 'block', 'data', {labelRule: $._name, eos: false}),
+    end_block_data_statement: $ => blockStructureEnding2($, 'block', 'data', $._name),
 
     assignment: $ => seq(caseInsensitive('assignment'), '(', '=', ')'),
     operator: $ => seq(caseInsensitive('operator'), '(', alias(/[^()]+/, $.operator_name), ')'),
@@ -437,7 +437,7 @@ module.exports = grammar({
       $._end_of_statement,
     ),
 
-    end_subroutine_statement: $ => blockStructureEnding1($, 'subroutine', {labelRule: $._name, eos: false}),
+    end_subroutine_statement: $ => blockStructureEnding1($, 'subroutine', $._name),
 
     module_procedure: $ => procedure($, $.module_procedure_statement, $.end_module_procedure_statement),
 
@@ -448,7 +448,7 @@ module.exports = grammar({
       $._end_of_statement,
     ),
 
-    end_module_procedure_statement: $ => blockStructureEnding1($, 'procedure', {labelRule: $._name, eos: false}),
+    end_module_procedure_statement: $ => blockStructureEnding1($, 'procedure', $._name),
 
     function: $ => procedure($, $.function_statement, $.end_function_statement),
 
@@ -491,7 +491,7 @@ module.exports = grammar({
       ')'
     )),
 
-    end_function_statement: $ => blockStructureEnding1($, 'function', {labelRule: $._name, eos: false}),
+    end_function_statement: $ => blockStructureEnding1($, 'function', $._name),
 
     function_result: $ => seq(
       caseInsensitive('result'),
@@ -772,7 +772,7 @@ module.exports = grammar({
       $._end_of_statement,
     ),
 
-    end_type_statement: $ => blockStructureEnding1($, 'type', {labelRule: $._name, eos: false}),
+    end_type_statement: $ => blockStructureEnding1($, 'type', $._name),
 
     _type_name: $ => alias($.identifier, $.type_name),
 
@@ -1363,13 +1363,13 @@ module.exports = grammar({
         field('do_label', alias($._do_label_continue, $.statement_label)),
         choice(
           $._statements,
-          blockStructureEnding1($, 'do', {labelRule: $._block_label, eos: false})
+          blockStructureEnding1($, 'do', $._block_label)
         )
       )
     ),
 
     // new style do loop, allows statement label as well as block label
-    end_do_loop_statement: $ => blockStructureEnding1($, 'do', {labelRule: $._block_label, eos: false}),
+    end_do_loop_statement: $ => blockStructureEnding1($, 'do', $._block_label),
 
     while_statement: $ => seq(caseInsensitive('while'),
       $.parenthesized_expression),
@@ -1459,7 +1459,7 @@ module.exports = grammar({
       $.end_if_statement
     ),
 
-    end_if_statement: $ => blockStructureEnding1($, 'if', {labelRule: $._block_label, eos: false}),
+    end_if_statement: $ => blockStructureEnding1($, 'if', $._block_label),
 
     elseif_clause: $ => seq(
       whiteSpacedKeyword('else', 'if'),
@@ -1498,7 +1498,7 @@ module.exports = grammar({
       $.end_where_statement
     ),
 
-    end_where_statement: $ => blockStructureEnding1($, 'where', {labelRule: $._block_label, eos: false}),
+    end_where_statement: $ => blockStructureEnding1($, 'where', $._block_label),
 
     elsewhere_clause: $ => seq(
       whiteSpacedKeyword('else', 'where'),
@@ -1547,7 +1547,7 @@ module.exports = grammar({
       $.end_forall_statement
     ),
 
-    end_forall_statement: $ => blockStructureEnding1($, 'forall', {labelRule: $._block_label, eos: false}),
+    end_forall_statement: $ => blockStructureEnding1($, 'forall', $._block_label),
 
     select_case_statement: $ => seq(
       optional($.block_label_start_expression),
@@ -1603,7 +1603,7 @@ module.exports = grammar({
       $.end_select_statement
     ),
 
-    end_select_statement: $ => blockStructureEnding1($, 'select', {labelRule: $._block_label, eos: false}),
+    end_select_statement: $ => blockStructureEnding1($, 'select', $._block_label),
 
     selector: $ => seq('(',
       choice($._expression, $.pointer_association_statement),
@@ -1666,7 +1666,7 @@ module.exports = grammar({
       $.end_block_construct_statement
     ),
 
-    end_block_construct_statement: $ => blockStructureEnding1($, 'block', {labelRule: $._block_label, eos: false}),
+    end_block_construct_statement: $ => blockStructureEnding1($, 'block', $._block_label),
 
     associate_statement: $ => seq(
       optional($.block_label_start_expression),
@@ -1689,7 +1689,7 @@ module.exports = grammar({
       field('selector', $._expression)
     ),
 
-    end_associate_statement: $ => blockStructureEnding1($, 'associate', {labelRule: $._block_label, eos: false}),
+    end_associate_statement: $ => blockStructureEnding1($, 'associate', $._block_label),
 
     format_statement: $ => prec.dynamic(PREC.CALL, seq(
       caseInsensitive('format'),
@@ -1815,9 +1815,9 @@ module.exports = grammar({
       )))
     ),
 
-    end_enum_statement: $ => blockStructureEnding1($, 'enum', {eos: false}),
+    end_enum_statement: $ => blockStructureEnding1($, 'enum'),
 
-    end_enumeration_type_statement: $ => blockStructureEnding2($, 'enumeration', 'type', {labelRule: $._name, eos: false}),
+    end_enumeration_type_statement: $ => blockStructureEnding2($, 'enumeration', 'type', $._name),
 
     // precedence is used to override a conflict with the complex literal
     unit_identifier: $ => seq(
@@ -2299,7 +2299,7 @@ module.exports = grammar({
     ),
 
     end_coarray_team_statement: $ => prec(2, seq(
-      blockStructureEnding1($, 'team', {eos: false}),
+      blockStructureEnding1($, 'team'),
       optional($.argument_list),
       optional($._block_label),
     )),
@@ -2313,7 +2313,7 @@ module.exports = grammar({
       $.end_coarray_critical_statement,
     ),
 
-    end_coarray_critical_statement: $ => blockStructureEnding1($, 'critical', {labelRule: $._block_label, eos: false}),
+    end_coarray_critical_statement: $ => blockStructureEnding1($, 'critical', $._block_label),
 
     conditional_expression: $ => seq(
       field('condition', $._expression),
@@ -2449,9 +2449,7 @@ function sep1 (rule, separator) {
 
 // one structType keyword
 // with optional rule for labels/names, and with optional end-of-statement
-function blockStructureEnding1 ($, structType, options) {
-  const { labelRule = null, eos = true } = options;
-
+function blockStructureEnding1 ($, structType, labelRule=null) {
   // just listing all combinations looks easier to read
   const end      = alias(caseInsensitive('end', false), 'end');
   const strt     = alias(caseInsensitive(structType, false), structType);
@@ -2466,15 +2464,13 @@ function blockStructureEnding1 ($, structType, options) {
     end
   );
 
-  return prec.right(eos ? seq(obj_end_stmt, $._end_of_statement) : obj_end_stmt)
+  return obj_end_stmt
 }
 
 // two structType keywords, example 'block' and 'data', accepted are
 // 'end', 'end block' and 'end block data', with or without white spaces,
 // with optional rule for labels/names, and with optional end-of-statement
-function blockStructureEnding2 ($, structType1, structType2, options) {
-  const { labelRule = null, eos = true } = options;
-
+function blockStructureEnding2 ($, structType1, structType2, labelRule=null) {
   const end          = alias(caseInsensitive('end', false), 'end');
   const strt_1       = alias(caseInsensitive(structType1, false), structType1);
   const strt_2       = alias(caseInsensitive(structType2, false), structType2);
@@ -2496,9 +2492,7 @@ function blockStructureEnding2 ($, structType1, structType2, options) {
     end
   );
 
-  // higher precedence, to avoid conflict like: is structType1+structType2 in statement
-  // part of end or does it start a new block? prefer binding to end
-  return prec.right(eos ? seq(obj_end_stmt, $._end_of_statement) : obj_end_stmt)
+  return obj_end_stmt
 }
 
 /**

--- a/grammar.js
+++ b/grammar.js
@@ -410,7 +410,7 @@ module.exports = grammar({
       $._end_of_statement
     ),
 
-    end_block_data_statement: $ => blockStructureEnding2($, 'block', 'data', $._name),
+    end_block_data_statement: $ => blockStructureEnding2($, 'block', 'data', $._name, false),
 
     assignment: $ => seq(caseInsensitive('assignment'), '(', '=', ')'),
     operator: $ => seq(caseInsensitive('operator'), '(', alias(/[^()]+/, $.operator_name), ')'),
@@ -1817,7 +1817,7 @@ module.exports = grammar({
 
     end_enum_statement: $ => blockStructureEnding1($, 'enum'),
 
-    end_enumeration_type_statement: $ => blockStructureEnding2($, 'enumeration', 'type', $._name),
+    end_enumeration_type_statement: $ => blockStructureEnding2($, 'enumeration', 'type', $._name, true),
 
     // precedence is used to override a conflict with the complex literal
     unit_identifier: $ => seq(
@@ -2470,7 +2470,7 @@ function blockStructureEnding1 ($, structType, labelRule=null) {
 // two structType keywords, example 'block' and 'data', accepted are
 // 'end', 'end block' and 'end block data', with or without white spaces,
 // with optional rule for labels/names, and with optional end-of-statement
-function blockStructureEnding2 ($, structType1, structType2, labelRule=null) {
+function blockStructureEnding2 ($, structType1, structType2, labelRule=null, require_blank=false) {
   const end          = alias(caseInsensitive('end', false), 'end');
   const strt_1       = alias(caseInsensitive(structType1, false), structType1);
   const strt_2       = alias(caseInsensitive(structType2, false), structType2);
@@ -2478,19 +2478,32 @@ function blockStructureEnding2 ($, structType1, structType2, labelRule=null) {
   const end_strt_1   = alias(caseInsensitive('end' + structType1, false), 'end' + structType1);
   const end_strt_1_2 = alias(caseInsensitive('end' + structType1 + structType2, false), 'end' + structType1 + structType2);
 
-  const obj_end_stmt = choice(
-    // when both structure keywords are present, allow the label
-    labelRule ? seq(end, strt_1, strt_2, optional(labelRule)) : seq(end, strt_1, strt_2),
-    labelRule ? seq(end_strt_1, strt_2,  optional(labelRule)) : seq(end_strt_1, strt_2),
-    labelRule ? seq(end, strt_1_2,       optional(labelRule)) : seq(end, strt_1_2),
-    labelRule ? seq(end_strt_1_2,        optional(labelRule)) : seq(end_strt_1_2),
-    // 'end' alone or with just one keyword does not accept a label,
-    // as this can grab other structure keywords
-    // in incomplete statements (which happens frequently during typing)
-    seq(end, strt_1),
-    end_strt_1,
-    end
-  );
+
+  let obj_end_stmt;
+
+  if (require_blank) {
+    // blank(s) between structure keywords are mandatory
+    obj_end_stmt = choice(
+      labelRule ? seq(end, strt_1, strt_2, optional(labelRule)) : seq(end, strt_1, strt_2),
+      seq(end, strt_1),
+      end_strt_1,
+      end
+    )
+  } else {
+    obj_end_stmt = choice(
+      // when both structure keywords are present, allow the label
+      labelRule ? seq(end, strt_1, strt_2, optional(labelRule)) : seq(end, strt_1, strt_2),
+      labelRule ? seq(end_strt_1, strt_2,  optional(labelRule)) : seq(end_strt_1, strt_2),
+      labelRule ? seq(end, strt_1_2,       optional(labelRule)) : seq(end, strt_1_2),
+      labelRule ? seq(end_strt_1_2,        optional(labelRule)) : seq(end_strt_1_2),
+      // 'end' alone or with just one keyword does not accept a label,
+      // as this can grab other structure keywords in incomplete statements
+      // (which happens frequently during typing)
+      seq(end, strt_1),
+      end_strt_1,
+      end
+    );
+  }
 
   return obj_end_stmt
 }

--- a/grammar.js
+++ b/grammar.js
@@ -379,11 +379,12 @@ module.exports = grammar({
       $._end_of_statement,
     ),
 
-    end_interface_statement: $ => prec.right(seq(
-      whiteSpacedKeyword('end', 'interface'),
-      optional(choice($._name, $._generic_procedure)),
-      $._end_of_statement
-    )),
+    end_interface_statement: $ => blockStructureEnding1($, 'interface', {labelRule: $._end_interface_spec, eos: true}),
+
+    _end_interface_spec: $ => choice(
+      $._name,
+      $._generic_procedure
+    ),
 
     // Obsolescent feature
     block_data: $ => seq(
@@ -404,18 +405,7 @@ module.exports = grammar({
       $._end_of_statement
     ),
 
-    // Can't use `blockStructureEnding` because it's two keywords
-    end_block_data_statement: $ => {
-      const structType = whiteSpacedKeyword('block', 'data', false)
-      return prec.right(seq(
-        choice(
-          seq(
-            alias(caseInsensitive('end', false), 'end'),
-            optional(alias(structType, 'blockdata'))),
-          alias(caseInsensitive('end' + structType, false), 'endblockdata')),
-        optional($._name),
-        $._end_of_statement))
-    },
+    end_block_data_statement: $ => blockStructureEnding2($, 'block', 'data', {labelRule: $._name, eos: true}),
 
     assignment: $ => seq(caseInsensitive('assignment'), '(', '=', ')'),
     operator: $ => seq(caseInsensitive('operator'), '(', alias(/[^()]+/, $.operator_name), ')'),
@@ -1314,8 +1304,6 @@ module.exports = grammar({
         optional($.block_label_start_expression),
         alias($.do_stmt_label, $.do_statement)
       ),
-      // or without block_label
-      // alias($.do_stmt_label, $.do_statement),
       seq(
         optional($.block_label_start_expression),
         alias($.do_stmt_nonlabel, $.do_statement)
@@ -1369,21 +1357,13 @@ module.exports = grammar({
         field('do_label', alias($._do_label_continue, $.statement_label)),
         choice(
           $._statements,
-          seq(
-            whiteSpacedKeyword('end', 'do'),
-            optional($._block_label)
-          )
-          // or without block_label
-          //whiteSpacedKeyword('end', 'do'),
+          blockStructureEnding1($, 'do', {labelRule: $._block_label, eos: false})
         )
       )
     ),
 
     // new style do loop, allows statement label as well as block label
-    end_do_loop_statement: $ => seq(
-      whiteSpacedKeyword('end', 'do'),
-      optional($._block_label)
-    ),
+    end_do_loop_statement: $ => blockStructureEnding1($, 'do', {labelRule: $._block_label, eos: false}),
 
     while_statement: $ => seq(caseInsensitive('while'),
       $.parenthesized_expression),
@@ -1473,10 +1453,7 @@ module.exports = grammar({
       $.end_if_statement
     ),
 
-    end_if_statement: $ => seq(
-      whiteSpacedKeyword('end', 'if'),
-      optional($._block_label)
-    ),
+    end_if_statement: $ => blockStructureEnding1($, 'if', {labelRule: $._block_label, eos: false}),
 
     elseif_clause: $ => seq(
       whiteSpacedKeyword('else', 'if'),
@@ -1515,10 +1492,7 @@ module.exports = grammar({
       $.end_where_statement
     ),
 
-    end_where_statement: $ => seq(
-      whiteSpacedKeyword('end', 'where'),
-      optional($._block_label)
-    ),
+    end_where_statement: $ => blockStructureEnding1($, 'where', {labelRule: $._block_label, eos: false}),
 
     elsewhere_clause: $ => seq(
       whiteSpacedKeyword('else', 'where'),
@@ -1567,10 +1541,7 @@ module.exports = grammar({
       $.end_forall_statement
     ),
 
-    end_forall_statement: $ => seq(
-      whiteSpacedKeyword('end', 'forall'),
-      optional($._block_label)
-    ),
+    end_forall_statement: $ => blockStructureEnding1($, 'forall', {labelRule: $._block_label, eos: false}),
 
     select_case_statement: $ => seq(
       optional($.block_label_start_expression),
@@ -1626,10 +1597,7 @@ module.exports = grammar({
       $.end_select_statement
     ),
 
-    end_select_statement: $ => seq(
-      whiteSpacedKeyword('end', 'select'),
-      optional($._block_label)
-    ),
+    end_select_statement: $ => blockStructureEnding1($, 'select', {labelRule: $._block_label, eos: false}),
 
     selector: $ => seq('(',
       choice($._expression, $.pointer_association_statement),
@@ -1692,10 +1660,7 @@ module.exports = grammar({
       $.end_block_construct_statement
     ),
 
-    end_block_construct_statement: $ => seq(
-      whiteSpacedKeyword('end', 'block'),
-      optional($._block_label)
-    ),
+    end_block_construct_statement: $ => blockStructureEnding1($, 'block', {labelRule: $._block_label, eos: false}),
 
     associate_statement: $ => seq(
       optional($.block_label_start_expression),
@@ -1718,10 +1683,7 @@ module.exports = grammar({
       field('selector', $._expression)
     ),
 
-    end_associate_statement: $ => seq(
-      whiteSpacedKeyword('end', 'associate'),
-      optional($._block_label)
-    ),
+    end_associate_statement: $ => blockStructureEnding1($, 'associate', {labelRule: $._block_label, eos: false}),
 
     format_statement: $ => prec.dynamic(PREC.CALL, seq(
       caseInsensitive('format'),
@@ -1847,13 +1809,9 @@ module.exports = grammar({
       )))
     ),
 
-    end_enum_statement: $ => whiteSpacedKeyword('end', 'enum'),
-    end_enumeration_type_statement: $ => seq(
-      caseInsensitive('end'),
-      caseInsensitive('enumeration'),
-      caseInsensitive('type'),
-      optional($._name)
-    ),
+    end_enum_statement: $ => blockStructureEnding1($, 'enum', {eos: false}),
+
+    end_enumeration_type_statement: $ => blockStructureEnding2($, 'enumeration', 'type', {labelRule: $._name, eos: false}),
 
     // precedence is used to override a conflict with the complex literal
     unit_identifier: $ => seq(
@@ -2334,11 +2292,11 @@ module.exports = grammar({
       $.end_coarray_team_statement,
     ),
 
-    end_coarray_team_statement: $ => seq(
-      whiteSpacedKeyword('end', 'team'),
+    end_coarray_team_statement: $ => prec(2, seq(
+      blockStructureEnding1($, 'team', {eos: false}),
       optional($.argument_list),
       optional($._block_label),
-    ),
+    )),
 
     coarray_critical_statement: $ => seq(
       optional($.block_label_start_expression),
@@ -2349,10 +2307,7 @@ module.exports = grammar({
       $.end_coarray_critical_statement,
     ),
 
-    end_coarray_critical_statement: $ => seq(
-      whiteSpacedKeyword('end', 'critical'),
-      optional($._block_label),
-    ),
+    end_coarray_critical_statement: $ => blockStructureEnding1($, 'critical', {labelRule: $._block_label, eos: false}),
 
     conditional_expression: $ => seq(
       field('condition', $._expression),
@@ -2498,6 +2453,59 @@ function blockStructureEnding ($, structType) {
     $._end_of_statement
   ))
   return obj
+}
+
+// one structType keyword
+// with optional rule for labels/names, and with optional end-of-statement
+function blockStructureEnding1 ($, structType, options) {
+  const { labelRule = null, eos = true } = options;
+
+  // just listing all combinations looks easier to read
+  const end      = alias(caseInsensitive('end', false), 'end');
+  const strt     = alias(caseInsensitive(structType, false), structType);
+  const end_strt = alias(caseInsensitive('end' + structType, false), 'end' + structType);
+
+  const obj_end_stmt = choice(
+    seq(end, strt),
+    end_strt,
+    end
+  );
+
+  // add label, but only if provided
+  const obj = prec.right(labelRule ? seq(obj_end_stmt, optional(labelRule)) : obj_end_stmt)
+  // higher precedence, to avoid conflict like: is 'do' in 'end do' part of end
+  // or does it start a new loop? prefer binding to end
+  return prec(1, eos ? seq(obj, $._end_of_statement) : obj)
+}
+
+// two structType keywords, example 'block' and 'data', accepted are
+// 'end', 'end block' and 'end block data', with or without white spaces,
+// with optional rule for labels/names, and with optional end-of-statement
+function blockStructureEnding2 ($, structType1, structType2, options) {
+  const { labelRule = null, eos = true } = options;
+
+  const end          = alias(caseInsensitive('end', false), 'end');
+  const strt_1       = alias(caseInsensitive(structType1, false), structType1);
+  const strt_2       = alias(caseInsensitive(structType2, false), structType2);
+  const strt_1_2     = alias(caseInsensitive(structType1 + structType2, false), structType1 + structType2);
+  const end_strt_1   = alias(caseInsensitive('end' + structType1, false), 'end' + structType1);
+  const end_strt_1_2 = alias(caseInsensitive('end' + structType1 + structType2, false), 'end' + structType1 + structType2);
+
+  const obj_end_stmt = choice(
+    seq(end, strt_1, strt_2),
+    seq(end, strt_1),
+    seq(end_strt_1, strt_2),
+    seq(end, strt_1_2),
+    end_strt_1_2,
+    end_strt_1,
+    end
+  );
+
+  // add label, but only if provided
+  const obj = prec.right(labelRule ? seq(obj_end_stmt, optional(labelRule)) : obj_end_stmt)
+  // higher precedence, to avoid conflict like: is structType1+structType2 in statement
+  // part of end or does it start a new block? prefer binding to end
+  return prec(1, eos ? seq(obj, $._end_of_statement) : obj)
 }
 
 /**

--- a/grammar.js
+++ b/grammar.js
@@ -300,6 +300,7 @@ module.exports = grammar({
       ),
       repeat($._statement),
       optional($.internal_procedures),
+      optional($.statement_label),
       $.end_program_statement,
       $._end_of_statement
     ),
@@ -2633,6 +2634,7 @@ function procedure($, start_statement, end_statement) {
       ),
     ),
     optional($.internal_procedures),
+    optional($.statement_label),
     end_statement,
     $._end_of_statement
   );

--- a/grammar.js
+++ b/grammar.js
@@ -2466,16 +2466,15 @@ function blockStructureEnding1 ($, structType, options) {
   const end_strt = alias(caseInsensitive('end' + structType, false), 'end' + structType);
 
   const obj_end_stmt = choice(
-    seq(end, strt),
-    end_strt,
+    // when structure keyword is present, allow the label
+    labelRule ? seq(end, strt, optional(labelRule)) : seq(end, strt),
+    labelRule ? seq(end_strt, optional(labelRule)) : end_strt,
+    // 'end' alone does not accept a label, as this can grab other structure keywords
+    // in incomplete statements (which happens frequently during typing)
     end
   );
 
-  // add label, but only if provided
-  const obj = prec.right(labelRule ? seq(obj_end_stmt, optional(labelRule)) : obj_end_stmt)
-  // higher precedence, to avoid conflict like: is 'do' in 'end do' part of end
-  // or does it start a new loop? prefer binding to end
-  return prec(1, eos ? seq(obj, $._end_of_statement) : obj)
+  return prec.right(eos ? seq(obj_end_stmt, $._end_of_statement) : obj_end_stmt)
 }
 
 // two structType keywords, example 'block' and 'data', accepted are
@@ -2492,20 +2491,22 @@ function blockStructureEnding2 ($, structType1, structType2, options) {
   const end_strt_1_2 = alias(caseInsensitive('end' + structType1 + structType2, false), 'end' + structType1 + structType2);
 
   const obj_end_stmt = choice(
-    seq(end, strt_1, strt_2),
+    // when both structure keywords are present, allow the label
+    labelRule ? seq(end, strt_1, strt_2, optional(labelRule)) : seq(end, strt_1, strt_2),
+    labelRule ? seq(end_strt_1, strt_2,  optional(labelRule)) : seq(end_strt_1, strt_2),
+    labelRule ? seq(end, strt_1_2,       optional(labelRule)) : seq(end, strt_1_2),
+    labelRule ? seq(end_strt_1_2,        optional(labelRule)) : seq(end_strt_1_2),
+    // 'end' alone or with just one keyword does not accept a label,
+    // as this can grab other structure keywords
+    // in incomplete statements (which happens frequently during typing)
     seq(end, strt_1),
-    seq(end_strt_1, strt_2),
-    seq(end, strt_1_2),
-    end_strt_1_2,
     end_strt_1,
     end
   );
 
-  // add label, but only if provided
-  const obj = prec.right(labelRule ? seq(obj_end_stmt, optional(labelRule)) : obj_end_stmt)
   // higher precedence, to avoid conflict like: is structType1+structType2 in statement
   // part of end or does it start a new block? prefer binding to end
-  return prec(1, eos ? seq(obj, $._end_of_statement) : obj)
+  return prec.right(eos ? seq(obj_end_stmt, $._end_of_statement) : obj_end_stmt)
 }
 
 /**

--- a/grammar.js
+++ b/grammar.js
@@ -304,7 +304,7 @@ module.exports = grammar({
     ),
 
     program_statement: $ => seq(caseInsensitive('program'), $._name, $._end_of_statement),
-    end_program_statement: $ => blockStructureEnding($, 'program'),
+    end_program_statement: $ => blockStructureEnding1($, 'program', {labelRule: $._name, eos: true}),
 
     module: $ => seq(
       $.module_statement,
@@ -320,7 +320,7 @@ module.exports = grammar({
     ),
 
     module_statement: $ => seq(caseInsensitive('module'), $._name, $._end_of_statement),
-    end_module_statement: $ => blockStructureEnding($, 'module'),
+    end_module_statement: $ => blockStructureEnding1($, 'module', {labelRule: $._name, eos: true}),
 
     submodule: $ => seq(
       $.submodule_statement,
@@ -346,7 +346,7 @@ module.exports = grammar({
       $._name,
       $._end_of_statement,
     ),
-    end_submodule_statement: $ => blockStructureEnding($, 'submodule'),
+    end_submodule_statement: $ => blockStructureEnding1($, 'submodule', {labelRule: $._name, eos: true}),
     module_name: $ => $._name,
 
     interface: $ => seq(
@@ -432,7 +432,7 @@ module.exports = grammar({
       $._end_of_statement,
     ),
 
-    end_subroutine_statement: $ => blockStructureEnding($, 'subroutine'),
+    end_subroutine_statement: $ => blockStructureEnding1($, 'subroutine', {labelRule: $._name, eos: true}),
 
     module_procedure: $ => procedure($, $.module_procedure_statement, $.end_module_procedure_statement),
 
@@ -443,7 +443,7 @@ module.exports = grammar({
       $._end_of_statement,
     ),
 
-    end_module_procedure_statement: $ => blockStructureEnding($, 'procedure'),
+    end_module_procedure_statement: $ => blockStructureEnding1($, 'procedure', {labelRule: $._name, eos: true}),
 
     function: $ => procedure($, $.function_statement, $.end_function_statement),
 
@@ -486,7 +486,7 @@ module.exports = grammar({
       ')'
     )),
 
-    end_function_statement: $ => blockStructureEnding($, 'function'),
+    end_function_statement: $ => blockStructureEnding1($, 'function', {labelRule: $._name, eos: true}),
 
     function_result: $ => seq(
       caseInsensitive('result'),
@@ -766,7 +766,7 @@ module.exports = grammar({
       $._end_of_statement,
     ),
 
-    end_type_statement: $ => blockStructureEnding($, 'type'),
+    end_type_statement: $ => blockStructureEnding1($, 'type', {labelRule: $._name, eos: true}),
 
     _type_name: $ => alias($.identifier, $.type_name),
 
@@ -2439,20 +2439,6 @@ function commaSep1 (rule) {
 
 function sep1 (rule, separator) {
   return seq(rule, repeat(seq(separator, rule)))
-}
-
-// This can be merged with whiteSpacedKeyword, keeping for now.
-function blockStructureEnding ($, structType) {
-  const obj = prec.right(seq(
-    choice(
-      seq(
-        alias(caseInsensitive('end', false), 'end'),
-        optional(alias(caseInsensitive(structType, false), structType))),
-      alias(caseInsensitive('end' + structType, false), 'end' + structType)),
-    optional($._name),
-    $._end_of_statement
-  ))
-  return obj
 }
 
 // one structType keyword

--- a/grammar.js
+++ b/grammar.js
@@ -300,11 +300,12 @@ module.exports = grammar({
       ),
       repeat($._statement),
       optional($.internal_procedures),
-      $.end_program_statement
+      $.end_program_statement,
+      $._end_of_statement
     ),
 
     program_statement: $ => seq(caseInsensitive('program'), $._name, $._end_of_statement),
-    end_program_statement: $ => blockStructureEnding1($, 'program', {labelRule: $._name, eos: true}),
+    end_program_statement: $ => blockStructureEnding1($, 'program', {labelRule: $._name, eos: false}),
 
     module: $ => seq(
       $.module_statement,
@@ -316,11 +317,12 @@ module.exports = grammar({
         ),
       ),
       optional($.internal_procedures),
-      $.end_module_statement
+      $.end_module_statement,
+      $._end_of_statement
     ),
 
     module_statement: $ => seq(caseInsensitive('module'), $._name, $._end_of_statement),
-    end_module_statement: $ => blockStructureEnding1($, 'module', {labelRule: $._name, eos: true}),
+    end_module_statement: $ => blockStructureEnding1($, 'module', {labelRule: $._name, eos: false}),
 
     submodule: $ => seq(
       $.submodule_statement,
@@ -332,7 +334,8 @@ module.exports = grammar({
         ),
       ),
       optional($.internal_procedures),
-      $.end_submodule_statement
+      $.end_submodule_statement,
+      $._end_of_statement
     ),
 
     submodule_statement: $ => seq(
@@ -346,7 +349,7 @@ module.exports = grammar({
       $._name,
       $._end_of_statement,
     ),
-    end_submodule_statement: $ => blockStructureEnding1($, 'submodule', {labelRule: $._name, eos: true}),
+    end_submodule_statement: $ => blockStructureEnding1($, 'submodule', {labelRule: $._name, eos: false}),
     module_name: $ => $._name,
 
     interface: $ => seq(
@@ -361,7 +364,8 @@ module.exports = grammar({
         alias($.preproc_if_in_interface, $.preproc_if),
         alias($.preproc_ifdef_in_interface, $.preproc_ifdef),
       )),
-      $.end_interface_statement
+      $.end_interface_statement,
+      $._end_of_statement
     ),
 
     _interface_items: $ => choice(
@@ -379,7 +383,7 @@ module.exports = grammar({
       $._end_of_statement,
     ),
 
-    end_interface_statement: $ => blockStructureEnding1($, 'interface', {labelRule: $._end_interface_spec, eos: true}),
+    end_interface_statement: $ => blockStructureEnding1($, 'interface', {labelRule: $._end_interface_spec, eos: false}),
 
     _end_interface_spec: $ => choice(
       $._name,
@@ -396,7 +400,8 @@ module.exports = grammar({
           alias($.preproc_ifdef_in_module, $.preproc_ifdef)
         ),
       ),
-      $.end_block_data_statement
+      $.end_block_data_statement,
+      $._end_of_statement
     ),
 
     block_data_statement: $ => seq(
@@ -405,7 +410,7 @@ module.exports = grammar({
       $._end_of_statement
     ),
 
-    end_block_data_statement: $ => blockStructureEnding2($, 'block', 'data', {labelRule: $._name, eos: true}),
+    end_block_data_statement: $ => blockStructureEnding2($, 'block', 'data', {labelRule: $._name, eos: false}),
 
     assignment: $ => seq(caseInsensitive('assignment'), '(', '=', ')'),
     operator: $ => seq(caseInsensitive('operator'), '(', alias(/[^()]+/, $.operator_name), ')'),
@@ -432,7 +437,7 @@ module.exports = grammar({
       $._end_of_statement,
     ),
 
-    end_subroutine_statement: $ => blockStructureEnding1($, 'subroutine', {labelRule: $._name, eos: true}),
+    end_subroutine_statement: $ => blockStructureEnding1($, 'subroutine', {labelRule: $._name, eos: false}),
 
     module_procedure: $ => procedure($, $.module_procedure_statement, $.end_module_procedure_statement),
 
@@ -443,7 +448,7 @@ module.exports = grammar({
       $._end_of_statement,
     ),
 
-    end_module_procedure_statement: $ => blockStructureEnding1($, 'procedure', {labelRule: $._name, eos: true}),
+    end_module_procedure_statement: $ => blockStructureEnding1($, 'procedure', {labelRule: $._name, eos: false}),
 
     function: $ => procedure($, $.function_statement, $.end_function_statement),
 
@@ -486,7 +491,7 @@ module.exports = grammar({
       ')'
     )),
 
-    end_function_statement: $ => blockStructureEnding1($, 'function', {labelRule: $._name, eos: true}),
+    end_function_statement: $ => blockStructureEnding1($, 'function', {labelRule: $._name, eos: false}),
 
     function_result: $ => seq(
       caseInsensitive('result'),
@@ -731,7 +736,8 @@ module.exports = grammar({
         alias($.preproc_ifdef_in_derived_type, $.preproc_ifdef),
       )),
       optional($.derived_type_procedures),
-      $.end_type_statement
+      $.end_type_statement,
+      $._end_of_statement
     ),
 
     abstract_specifier: $ => caseInsensitive('abstract'),
@@ -766,7 +772,7 @@ module.exports = grammar({
       $._end_of_statement,
     ),
 
-    end_type_statement: $ => blockStructureEnding1($, 'type', {labelRule: $._name, eos: true}),
+    end_type_statement: $ => blockStructureEnding1($, 'type', {labelRule: $._name, eos: false}),
 
     _type_name: $ => alias($.identifier, $.type_name),
 
@@ -2620,6 +2626,7 @@ function procedure($, start_statement, end_statement) {
       ),
     ),
     optional($.internal_procedures),
-    end_statement
+    end_statement,
+    $._end_of_statement
   );
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7959,8 +7959,24 @@
           ]
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "statement_label"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "end_program_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_of_statement"
         }
       ]
     },
@@ -7987,74 +8003,79 @@
       ]
     },
     "end_program_statement": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
-                    },
-                    "named": false,
-                    "value": "end"
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[pP][rR][oO][gG][rR][aA][mM]"
-                        },
-                        "named": false,
-                        "value": "program"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  }
-                ]
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
               },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[eE][nN][dD][pP][rR][oO][gG][rR][aA][mM]"
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[pP][rR][oO][gG][rR][aA][mM]"
+              },
+              "named": false,
+              "value": "program"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
                 },
-                "named": false,
-                "value": "endprogram"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_name"
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD][pP][rR][oO][gG][rR][aA][mM]"
               },
-              {
-                "type": "BLANK"
-              }
-            ]
+              "named": false,
+              "value": "endprogram"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
           },
-          {
-            "type": "SYMBOL",
-            "name": "_end_of_statement"
-          }
-        ]
-      }
+          "named": false,
+          "value": "end"
+        }
+      ]
     },
     "module": {
       "type": "SEQ",
@@ -8108,6 +8129,10 @@
         {
           "type": "SYMBOL",
           "name": "end_module_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_of_statement"
         }
       ]
     },
@@ -8134,74 +8159,79 @@
       ]
     },
     "end_module_statement": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
-                    },
-                    "named": false,
-                    "value": "end"
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[mM][oO][dD][uU][lL][eE]"
-                        },
-                        "named": false,
-                        "value": "module"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  }
-                ]
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
               },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[eE][nN][dD][mM][oO][dD][uU][lL][eE]"
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[mM][oO][dD][uU][lL][eE]"
+              },
+              "named": false,
+              "value": "module"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
                 },
-                "named": false,
-                "value": "endmodule"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_name"
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD][mM][oO][dD][uU][lL][eE]"
               },
-              {
-                "type": "BLANK"
-              }
-            ]
+              "named": false,
+              "value": "endmodule"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
           },
-          {
-            "type": "SYMBOL",
-            "name": "_end_of_statement"
-          }
-        ]
-      }
+          "named": false,
+          "value": "end"
+        }
+      ]
     },
     "submodule": {
       "type": "SEQ",
@@ -8255,6 +8285,10 @@
         {
           "type": "SYMBOL",
           "name": "end_submodule_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_of_statement"
         }
       ]
     },
@@ -8322,74 +8356,79 @@
       ]
     },
     "end_submodule_statement": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
-                    },
-                    "named": false,
-                    "value": "end"
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[sS][uU][bB][mM][oO][dD][uU][lL][eE]"
-                        },
-                        "named": false,
-                        "value": "submodule"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  }
-                ]
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
               },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[eE][nN][dD][sS][uU][bB][mM][oO][dD][uU][lL][eE]"
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[sS][uU][bB][mM][oO][dD][uU][lL][eE]"
+              },
+              "named": false,
+              "value": "submodule"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
                 },
-                "named": false,
-                "value": "endsubmodule"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_name"
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD][sS][uU][bB][mM][oO][dD][uU][lL][eE]"
               },
-              {
-                "type": "BLANK"
-              }
-            ]
+              "named": false,
+              "value": "endsubmodule"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
           },
-          {
-            "type": "SYMBOL",
-            "name": "_end_of_statement"
-          }
-        ]
-      }
+          "named": false,
+          "value": "end"
+        }
+      ]
     },
     "module_name": {
       "type": "SYMBOL",
@@ -8455,6 +8494,10 @@
         {
           "type": "SYMBOL",
           "name": "end_interface_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_of_statement"
         }
       ]
     },
@@ -8535,75 +8578,92 @@
       ]
     },
     "end_interface_statement": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
-                    },
-                    "named": false,
-                    "value": "end"
-                  },
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[iI][nN][tT][eE][rR][fF][aA][cC][eE]"
-                    },
-                    "named": false,
-                    "value": "interface"
-                  }
-                ]
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
               },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[eE][nN][dD][iI][nN][tT][eE][rR][fF][aA][cC][eE]"
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[iI][nN][tT][eE][rR][fF][aA][cC][eE]"
+              },
+              "named": false,
+              "value": "interface"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_end_interface_spec"
                 },
-                "named": false,
-                "value": "endinterface"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_name"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_generic_procedure"
-                  }
-                ]
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD][iI][nN][tT][eE][rR][fF][aA][cC][eE]"
               },
-              {
-                "type": "BLANK"
-              }
-            ]
+              "named": false,
+              "value": "endinterface"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_end_interface_spec"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
           },
-          {
-            "type": "SYMBOL",
-            "name": "_end_of_statement"
-          }
-        ]
-      }
+          "named": false,
+          "value": "end"
+        }
+      ]
+    },
+    "_end_interface_spec": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_generic_procedure"
+        }
+      ]
     },
     "block_data": {
       "type": "SEQ",
@@ -8645,6 +8705,10 @@
         {
           "type": "SYMBOL",
           "name": "end_block_data_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_of_statement"
         }
       ]
     },
@@ -8707,92 +8771,190 @@
       ]
     },
     "end_block_data_statement": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
-                    },
-                    "named": false,
-                    "value": "end"
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "SEQ",
-                              "members": [
-                                {
-                                  "type": "PATTERN",
-                                  "value": "[bB][lL][oO][cC][kK]"
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "[dD][aA][tT][aA]"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "PATTERN",
-                              "value": "[bB][lL][oO][cC][kK][dD][aA][tT][aA]"
-                            }
-                          ]
-                        },
-                        "named": false,
-                        "value": "blockdata"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  }
-                ]
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
               },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[eE][nN][dD][[oO][bB][jJ][eE][cC][tT] O[bB][jJ][eE][cC][tT]]"
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[bB][lL][oO][cC][kK]"
+              },
+              "named": false,
+              "value": "block"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[dD][aA][tT][aA]"
+              },
+              "named": false,
+              "value": "data"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
                 },
-                "named": false,
-                "value": "endblockdata"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_name"
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD][bB][lL][oO][cC][kK]"
               },
-              {
-                "type": "BLANK"
-              }
-            ]
+              "named": false,
+              "value": "endblock"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[dD][aA][tT][aA]"
+              },
+              "named": false,
+              "value": "data"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
+              },
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[bB][lL][oO][cC][kK][dD][aA][tT][aA]"
+              },
+              "named": false,
+              "value": "blockdata"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD][bB][lL][oO][cC][kK][dD][aA][tT][aA]"
+              },
+              "named": false,
+              "value": "endblockdata"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
+              },
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[bB][lL][oO][cC][kK]"
+              },
+              "named": false,
+              "value": "block"
+            }
+          ]
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD][bB][lL][oO][cC][kK]"
           },
-          {
-            "type": "SYMBOL",
-            "name": "_end_of_statement"
-          }
-        ]
-      }
+          "named": false,
+          "value": "endblock"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
+          },
+          "named": false,
+          "value": "end"
+        }
+      ]
     },
     "assignment": {
       "type": "SEQ",
@@ -9007,8 +9169,24 @@
           ]
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "statement_label"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "end_subroutine_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_of_statement"
         }
       ]
     },
@@ -9079,74 +9257,79 @@
       ]
     },
     "end_subroutine_statement": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
-                    },
-                    "named": false,
-                    "value": "end"
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[sS][uU][bB][rR][oO][uU][tT][iI][nN][eE]"
-                        },
-                        "named": false,
-                        "value": "subroutine"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  }
-                ]
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
               },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[eE][nN][dD][sS][uU][bB][rR][oO][uU][tT][iI][nN][eE]"
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[sS][uU][bB][rR][oO][uU][tT][iI][nN][eE]"
+              },
+              "named": false,
+              "value": "subroutine"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
                 },
-                "named": false,
-                "value": "endsubroutine"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_name"
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD][sS][uU][bB][rR][oO][uU][tT][iI][nN][eE]"
               },
-              {
-                "type": "BLANK"
-              }
-            ]
+              "named": false,
+              "value": "endsubroutine"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
           },
-          {
-            "type": "SYMBOL",
-            "name": "_end_of_statement"
-          }
-        ]
-      }
+          "named": false,
+          "value": "end"
+        }
+      ]
     },
     "module_procedure": {
       "type": "SEQ",
@@ -9228,8 +9411,24 @@
           ]
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "statement_label"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "end_module_procedure_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_of_statement"
         }
       ]
     },
@@ -9286,74 +9485,79 @@
       ]
     },
     "end_module_procedure_statement": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
-                    },
-                    "named": false,
-                    "value": "end"
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[pP][rR][oO][cC][eE][dD][uU][rR][eE]"
-                        },
-                        "named": false,
-                        "value": "procedure"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  }
-                ]
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
               },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[eE][nN][dD][pP][rR][oO][cC][eE][dD][uU][rR][eE]"
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[pP][rR][oO][cC][eE][dD][uU][rR][eE]"
+              },
+              "named": false,
+              "value": "procedure"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
                 },
-                "named": false,
-                "value": "endprocedure"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_name"
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD][pP][rR][oO][cC][eE][dD][uU][rR][eE]"
               },
-              {
-                "type": "BLANK"
-              }
-            ]
+              "named": false,
+              "value": "endprocedure"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
           },
-          {
-            "type": "SYMBOL",
-            "name": "_end_of_statement"
-          }
-        ]
-      }
+          "named": false,
+          "value": "end"
+        }
+      ]
     },
     "function": {
       "type": "SEQ",
@@ -9435,8 +9639,24 @@
           ]
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "statement_label"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "end_function_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_of_statement"
         }
       ]
     },
@@ -9727,74 +9947,79 @@
       }
     },
     "end_function_statement": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
-                    },
-                    "named": false,
-                    "value": "end"
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[fF][uU][nN][cC][tT][iI][oO][nN]"
-                        },
-                        "named": false,
-                        "value": "function"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  }
-                ]
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
               },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[eE][nN][dD][fF][uU][nN][cC][tT][iI][oO][nN]"
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[fF][uU][nN][cC][tT][iI][oO][nN]"
+              },
+              "named": false,
+              "value": "function"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
                 },
-                "named": false,
-                "value": "endfunction"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_name"
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD][fF][uU][nN][cC][tT][iI][oO][nN]"
               },
-              {
-                "type": "BLANK"
-              }
-            ]
+              "named": false,
+              "value": "endfunction"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
           },
-          {
-            "type": "SYMBOL",
-            "name": "_end_of_statement"
-          }
-        ]
-      }
+          "named": false,
+          "value": "end"
+        }
+      ]
     },
     "function_result": {
       "type": "SEQ",
@@ -11351,6 +11576,10 @@
         {
           "type": "SYMBOL",
           "name": "end_type_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_end_of_statement"
         }
       ]
     },
@@ -11557,74 +11786,79 @@
       ]
     },
     "end_type_statement": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[eE][nN][dD]"
-                    },
-                    "named": false,
-                    "value": "end"
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[tT][yY][pP][eE]"
-                        },
-                        "named": false,
-                        "value": "type"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  }
-                ]
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
               },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[eE][nN][dD][tT][yY][pP][eE]"
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[tT][yY][pP][eE]"
+              },
+              "named": false,
+              "value": "type"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
                 },
-                "named": false,
-                "value": "endtype"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_name"
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD][tT][yY][pP][eE]"
               },
-              {
-                "type": "BLANK"
-              }
-            ]
+              "named": false,
+              "value": "endtype"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
           },
-          {
-            "type": "SYMBOL",
-            "name": "_end_of_statement"
-          }
-        ]
-      }
+          "named": false,
+          "value": "end"
+        }
+      ]
     },
     "_type_name": {
       "type": "ALIAS",
@@ -15258,34 +15492,46 @@
                   "name": "_statements"
                 },
                 {
-                  "type": "SEQ",
+                  "type": "CHOICE",
                   "members": [
                     {
-                      "type": "CHOICE",
+                      "type": "SEQ",
                       "members": [
                         {
-                          "type": "SEQ",
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "PATTERN",
+                            "value": "[eE][nN][dD]"
+                          },
+                          "named": false,
+                          "value": "end"
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "PATTERN",
+                            "value": "[dD][oO]"
+                          },
+                          "named": false,
+                          "value": "do"
+                        },
+                        {
+                          "type": "CHOICE",
                           "members": [
                             {
-                              "type": "ALIAS",
-                              "content": {
-                                "type": "PATTERN",
-                                "value": "[eE][nN][dD]"
-                              },
-                              "named": false,
-                              "value": "end"
+                              "type": "SYMBOL",
+                              "name": "_block_label"
                             },
                             {
-                              "type": "ALIAS",
-                              "content": {
-                                "type": "PATTERN",
-                                "value": "[dD][oO]"
-                              },
-                              "named": false,
-                              "value": "do"
+                              "type": "BLANK"
                             }
                           ]
-                        },
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
                         {
                           "type": "ALIAS",
                           "content": {
@@ -15294,20 +15540,29 @@
                           },
                           "named": false,
                           "value": "enddo"
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "_block_label"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
                         }
                       ]
                     },
                     {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "_block_label"
-                        },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[eE][nN][dD]"
+                      },
+                      "named": false,
+                      "value": "end"
                     }
                   ]
                 }
@@ -15318,34 +15573,46 @@
       ]
     },
     "end_do_loop_statement": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
+              },
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[dD][oO]"
+              },
+              "named": false,
+              "value": "do"
+            },
+            {
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
-                  },
-                  "named": false,
-                  "value": "end"
+                  "type": "SYMBOL",
+                  "name": "_block_label"
                 },
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[dD][oO]"
-                  },
-                  "named": false,
-                  "value": "do"
+                  "type": "BLANK"
                 }
               ]
-            },
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
             {
               "type": "ALIAS",
               "content": {
@@ -15354,20 +15621,29 @@
               },
               "named": false,
               "value": "enddo"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_block_label"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_block_label"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
+          },
+          "named": false,
+          "value": "end"
         }
       ]
     },
@@ -15914,34 +16190,46 @@
       ]
     },
     "end_if_statement": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
+              },
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[iI][fF]"
+              },
+              "named": false,
+              "value": "if"
+            },
+            {
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
-                  },
-                  "named": false,
-                  "value": "end"
+                  "type": "SYMBOL",
+                  "name": "_block_label"
                 },
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[iI][fF]"
-                  },
-                  "named": false,
-                  "value": "if"
+                  "type": "BLANK"
                 }
               ]
-            },
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
             {
               "type": "ALIAS",
               "content": {
@@ -15950,20 +16238,29 @@
               },
               "named": false,
               "value": "endif"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_block_label"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_block_label"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
+          },
+          "named": false,
+          "value": "end"
         }
       ]
     },
@@ -16174,34 +16471,46 @@
       ]
     },
     "end_where_statement": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
+              },
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[wW][hH][eE][rR][eE]"
+              },
+              "named": false,
+              "value": "where"
+            },
+            {
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
-                  },
-                  "named": false,
-                  "value": "end"
+                  "type": "SYMBOL",
+                  "name": "_block_label"
                 },
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[wW][hH][eE][rR][eE]"
-                  },
-                  "named": false,
-                  "value": "where"
+                  "type": "BLANK"
                 }
               ]
-            },
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
             {
               "type": "ALIAS",
               "content": {
@@ -16210,20 +16519,29 @@
               },
               "named": false,
               "value": "endwhere"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_block_label"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_block_label"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
+          },
+          "named": false,
+          "value": "end"
         }
       ]
     },
@@ -16502,34 +16820,46 @@
       ]
     },
     "end_forall_statement": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
+              },
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[fF][oO][rR][aA][lL][lL]"
+              },
+              "named": false,
+              "value": "forall"
+            },
+            {
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
-                  },
-                  "named": false,
-                  "value": "end"
+                  "type": "SYMBOL",
+                  "name": "_block_label"
                 },
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[fF][oO][rR][aA][lL][lL]"
-                  },
-                  "named": false,
-                  "value": "forall"
+                  "type": "BLANK"
                 }
               ]
-            },
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
             {
               "type": "ALIAS",
               "content": {
@@ -16538,20 +16868,29 @@
               },
               "named": false,
               "value": "endforall"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_block_label"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_block_label"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
+          },
+          "named": false,
+          "value": "end"
         }
       ]
     },
@@ -16928,34 +17267,46 @@
       ]
     },
     "end_select_statement": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
+              },
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[sS][eE][lL][eE][cC][tT]"
+              },
+              "named": false,
+              "value": "select"
+            },
+            {
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
-                  },
-                  "named": false,
-                  "value": "end"
+                  "type": "SYMBOL",
+                  "name": "_block_label"
                 },
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[sS][eE][lL][eE][cC][tT]"
-                  },
-                  "named": false,
-                  "value": "select"
+                  "type": "BLANK"
                 }
               ]
-            },
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
             {
               "type": "ALIAS",
               "content": {
@@ -16964,20 +17315,29 @@
               },
               "named": false,
               "value": "endselect"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_block_label"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_block_label"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
+          },
+          "named": false,
+          "value": "end"
         }
       ]
     },
@@ -17429,34 +17789,46 @@
       ]
     },
     "end_block_construct_statement": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
+              },
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[bB][lL][oO][cC][kK]"
+              },
+              "named": false,
+              "value": "block"
+            },
+            {
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
-                  },
-                  "named": false,
-                  "value": "end"
+                  "type": "SYMBOL",
+                  "name": "_block_label"
                 },
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[bB][lL][oO][cC][kK]"
-                  },
-                  "named": false,
-                  "value": "block"
+                  "type": "BLANK"
                 }
               ]
-            },
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
             {
               "type": "ALIAS",
               "content": {
@@ -17465,20 +17837,29 @@
               },
               "named": false,
               "value": "endblock"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_block_label"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_block_label"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
+          },
+          "named": false,
+          "value": "end"
         }
       ]
     },
@@ -17591,34 +17972,46 @@
       ]
     },
     "end_associate_statement": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
+              },
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[aA][sS][sS][oO][cC][iI][aA][tT][eE]"
+              },
+              "named": false,
+              "value": "associate"
+            },
+            {
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
-                  },
-                  "named": false,
-                  "value": "end"
+                  "type": "SYMBOL",
+                  "name": "_block_label"
                 },
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[aA][sS][sS][oO][cC][iI][aA][tT][eE]"
-                  },
-                  "named": false,
-                  "value": "associate"
+                  "type": "BLANK"
                 }
               ]
-            },
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
             {
               "type": "ALIAS",
               "content": {
@@ -17627,20 +18020,29 @@
               },
               "named": false,
               "value": "endassociate"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_block_label"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_block_label"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
+          },
+          "named": false,
+          "value": "end"
         }
       ]
     },
@@ -18495,12 +18897,7 @@
           },
           "named": false,
           "value": "endenum"
-        }
-      ]
-    },
-    "end_enumeration_type_statement": {
-      "type": "SEQ",
-      "members": [
+        },
         {
           "type": "ALIAS",
           "content": {
@@ -18509,36 +18906,96 @@
           },
           "named": false,
           "value": "end"
-        },
+        }
+      ]
+    },
+    "end_enumeration_type_statement": {
+      "type": "CHOICE",
+      "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[eE][nN][uU][mM][eE][rR][aA][tT][iI][oO][nN]"
-          },
-          "named": false,
-          "value": "enumeration"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[tT][yY][pP][eE]"
-          },
-          "named": false,
-          "value": "type"
-        },
-        {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_name"
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
+              },
+              "named": false,
+              "value": "end"
             },
             {
-              "type": "BLANK"
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][uU][mM][eE][rR][aA][tT][iI][oO][nN]"
+              },
+              "named": false,
+              "value": "enumeration"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[tT][yY][pP][eE]"
+              },
+              "named": false,
+              "value": "type"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_name"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
+              },
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][uU][mM][eE][rR][aA][tT][iI][oO][nN]"
+              },
+              "named": false,
+              "value": "enumeration"
+            }
+          ]
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD][eE][nN][uU][mM][eE][rR][aA][tT][iI][oO][nN]"
+          },
+          "named": false,
+          "value": "endenumeration"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
+          },
+          "named": false,
+          "value": "end"
         }
       ]
     },
@@ -21741,70 +22198,83 @@
       ]
     },
     "end_coarray_team_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
+      "type": "PREC",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[eE][nN][dD]"
+                    },
+                    "named": false,
+                    "value": "end"
                   },
-                  "named": false,
-                  "value": "end"
-                },
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[tT][eE][aA][mM]"
-                  },
-                  "named": false,
-                  "value": "team"
-                }
-              ]
-            },
-            {
-              "type": "ALIAS",
-              "content": {
-                "type": "PATTERN",
-                "value": "[eE][nN][dD][tT][eE][aA][mM]"
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[tT][eE][aA][mM]"
+                    },
+                    "named": false,
+                    "value": "team"
+                  }
+                ]
               },
-              "named": false,
-              "value": "endteam"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "argument_list"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_block_label"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[eE][nN][dD][tT][eE][aA][mM]"
+                },
+                "named": false,
+                "value": "endteam"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[eE][nN][dD]"
+                },
+                "named": false,
+                "value": "end"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "argument_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_block_label"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "coarray_critical_statement": {
       "type": "SEQ",
@@ -21860,34 +22330,46 @@
       ]
     },
     "end_coarray_critical_statement": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[eE][nN][dD]"
+              },
+              "named": false,
+              "value": "end"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[cC][rR][iI][tT][iI][cC][aA][lL]"
+              },
+              "named": false,
+              "value": "critical"
+            },
+            {
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[eE][nN][dD]"
-                  },
-                  "named": false,
-                  "value": "end"
+                  "type": "SYMBOL",
+                  "name": "_block_label"
                 },
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[cC][rR][iI][tT][iI][cC][aA][lL]"
-                  },
-                  "named": false,
-                  "value": "critical"
+                  "type": "BLANK"
                 }
               ]
-            },
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
             {
               "type": "ALIAS",
               "content": {
@@ -21896,20 +22378,29 @@
               },
               "named": false,
               "value": "endcritical"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_block_label"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_block_label"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "[eE][nN][dD]"
+          },
+          "named": false,
+          "value": "end"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -7480,6 +7480,10 @@
     "named": false
   },
   {
+    "type": "endenumeration",
+    "named": false
+  },
+  {
     "type": "endfile",
     "named": false
   },

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -1462,3 +1462,46 @@ Block Data (Obsolescent)
       (name))
     (end_block_data_statement
       (name))))
+
+================================================================================
+Statement labels on construct end
+================================================================================
+
+program test
+contains
+    subroutine foo
+    10 end subroutine foo
+
+    integer function bar
+      bar = 20
+    20 end function bar
+
+30 end program test
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (program
+    (program_statement
+      (name))
+    (internal_procedures
+      (contains_statement)
+      (subroutine
+        (subroutine_statement
+          (name))
+        (statement_label)
+        (end_subroutine_statement
+          (name)))
+      (function
+        (function_statement
+          (intrinsic_type)
+          (name))
+        (assignment_statement
+          (identifier)
+          (number_literal))
+        (statement_label)
+        (end_function_statement
+          (name))))
+    (statement_label)
+    (end_program_statement
+      (name))))

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -1417,6 +1417,12 @@ Block Data (Obsolescent)
       DATA ICASE /4/
       END
 
+      block data name2
+      end block data
+
+      Block Data name3
+      End Block Data name3
+
 --------------------------------------------------------------------------------
 
 (translation_unit
@@ -1434,4 +1440,13 @@ Block Data (Obsolescent)
         (identifier)
         (data_value
           (number_literal))))
-    (end_block_data_statement)))
+    (end_block_data_statement))
+  (block_data
+    (block_data_statement
+      (name))
+    (end_block_data_statement))
+  (block_data
+    (block_data_statement
+      (name))
+    (end_block_data_statement
+      (name))))

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -1385,6 +1385,10 @@ module enumeration_mod
     enumerator :: v_one, v_two, v_three
     enumerator v_four
   end enumeration type v_value
+
+  ENUMERATION TYPE :: editor
+    ENUMERATOR :: emacs, vim, ed
+  END ENUMERATION TYPE
 end module enumeration_mod
 
 --------------------------------------------------------------------------------
@@ -1405,6 +1409,14 @@ end module enumeration_mod
         (identifier))
       (end_enumeration_type_statement
         (name)))
+    (enumeration_type
+      (enumeration_type_statement
+        (type_name))
+      (enumerator_statement
+        (identifier)
+        (identifier)
+        (identifier))
+      (end_enumeration_type_statement))
     (end_module_statement
       (name))))
 


### PR DESCRIPTION
Refactor and extend end structure type parsing.
* Allow incomplete `end` statements without structure keyword for all structures (previously only a few like subroutine).
* Fix consumation of end of statement (do not include the token in the statement node itself), making it consistent with other statements
* Allow `EnumerationType` without space character(s) in between
* Allow (incomplete) variants for `end block data` and `end enumeration type`

Note: `npm run generate` has not yet been run on this branch!