### PR TITLE
Add missing fields for operator .not.

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -629,7 +629,7 @@ module.exports = grammar({
           ')'
         )),
         seq(
-          alias(caseInsensitive('none', false), $.none),
+          caseInsensitive('none', $.none),
           optional(seq(
             '(',
             commaSep1(choice(
@@ -723,7 +723,7 @@ module.exports = grammar({
           choice(
             $.public_statement,
             $.private_statement,
-            alias(caseInsensitive('sequence'), $.sequence_statement),
+            caseInsensitive('sequence', $.sequence_statement),
             $.include_statement,
           ),
           $._end_of_statement
@@ -1614,7 +1614,7 @@ module.exports = grammar({
       caseInsensitive('case'),
       choice(
         seq('(', $.case_value_range_list, ')'),
-        alias(caseInsensitive('default'), $.default)
+        caseInsensitive('default', $.default)
       ),
       optional($._block_label),
       $._end_of_statement,
@@ -1634,7 +1634,7 @@ module.exports = grammar({
         ),
         seq(
           caseInsensitive('class'),
-          alias(caseInsensitive('default'), $.default)
+          caseInsensitive('default', $.default)
         ),
       ),
       optional($._block_label),
@@ -1652,7 +1652,7 @@ module.exports = grammar({
       choice(
         seq('(', $.case_value_range_list, ')'),
         seq('(', $.assumed_size, ')'),
-        alias(caseInsensitive('default'), $.default)
+        caseInsensitive('default', $.default)
       ),
       optional($._block_label),
       $._end_of_statement,
@@ -2412,8 +2412,11 @@ module.exports = grammar({
 
 module.exports.PREC = PREC
 
-function caseInsensitive (keyword, aliasAsWord = true) {
-  let result = new RegExp(keyword
+// always use alias, as a regexp is used to compare case-insensitively,
+// default is to use the keyword itself, but a rule/named node $.my_name
+// can be provided optionally
+function caseInsensitive (keyword, aliasValue = keyword) {
+  const pattern = keyword
     .split('')
     .map(l => {
       if (l.match(/[a-zA-Z]/)) return `[${l.toLowerCase()}${l.toUpperCase()}]`
@@ -2422,9 +2425,9 @@ function caseInsensitive (keyword, aliasAsWord = true) {
       throw new Error(`caseInsensitive: unhandled character '${l}' in keyword '${keyword}'`)
     })
     .join('')
-  )
-  if (aliasAsWord) result = alias(result, keyword)
-  return result
+
+  // default: aliasValue = keyword
+  return alias(new RegExp(pattern), aliasValue)
 }
 
 

--- a/grammar.js
+++ b/grammar.js
@@ -1984,10 +1984,10 @@ module.exports = grammar({
 
     logical_expression: $ => {
       const table = [
-        [caseInsensitive('\\.or\\.'), PREC.LOGICAL_OR],
-        [caseInsensitive('\\.and\\.'), PREC.LOGICAL_AND],
-        [caseInsensitive('\\.eqv\\.'), PREC.LOGICAL_EQUIV],
-        [caseInsensitive('\\.neqv\\.'), PREC.LOGICAL_EQUIV]
+        [caseInsensitive('.or.'), PREC.LOGICAL_OR],
+        [caseInsensitive('.and.'), PREC.LOGICAL_AND],
+        [caseInsensitive('.eqv.'), PREC.LOGICAL_EQUIV],
+        [caseInsensitive('.neqv.'), PREC.LOGICAL_EQUIV]
       ]
 
       return choice(...table.map(([operator, precedence]) => {
@@ -1997,24 +1997,24 @@ module.exports = grammar({
           field('right', $._expression)
         ))
       }).concat(
-        [prec.left(PREC.LOGICAL_NOT, seq(caseInsensitive('\\.not\\.'), $._expression))])
+        [prec.left(PREC.LOGICAL_NOT, seq(caseInsensitive('.not.'), $._expression))])
       )
     },
 
     relational_expression: $ => {
       const operators = [
         '<',
-        caseInsensitive('\\.lt\\.'),
+        caseInsensitive('.lt.'),
         '>',
-        caseInsensitive('\\.gt\\.'),
+        caseInsensitive('.gt.'),
         '<=',
-        caseInsensitive('\\.le\\.'),
+        caseInsensitive('.le.'),
         '>=',
-        caseInsensitive('\\.ge\\.'),
+        caseInsensitive('.ge.'),
         '==',
-        caseInsensitive('\\.eq\\.'),
+        caseInsensitive('.eq.'),
         '/=',
-        caseInsensitive('\\.ne\\.')
+        caseInsensitive('.ne.')
       ]
 
       return choice(...operators.map((operator) => {
@@ -2176,8 +2176,8 @@ module.exports = grammar({
 
     boolean_literal: $ => seq(
       choice(
-        caseInsensitive('\\.true\\.'),
-        caseInsensitive('\\.false\\.')
+        caseInsensitive('.true.'),
+        caseInsensitive('.false.')
       ),
       optional($._kind)
     ),
@@ -2327,7 +2327,7 @@ module.exports = grammar({
 
     // Strictly only valid when used in a conditional_expression as an
     // actual argument
-    nil_literal: $ => caseInsensitive('\\.nil\\.'),
+    nil_literal: $ => caseInsensitive('.nil.'),
 
     // Fortran doesn't have reserved keywords, and to allow _just
     // enough_ ambiguity so that tree-sitter can parse tokens
@@ -2415,22 +2415,23 @@ module.exports.PREC = PREC
 function caseInsensitive (keyword, aliasAsWord = true) {
   let result = new RegExp(keyword
     .split('')
-    .map(l => l !== l.toUpperCase() ? `[${l}${l.toUpperCase()}]` : l)
+    .map(l => {
+      if (l.match(/[a-zA-Z]/)) return `[${l.toLowerCase()}${l.toUpperCase()}]`
+      if (l.match(/[0-9_]/))   return l
+      if (l === '.')           return '\\.'
+      throw new Error(`caseInsensitive: unhandled character '${l}' in keyword '${keyword}'`)
+    })
     .join('')
   )
   if (aliasAsWord) result = alias(result, keyword)
   return result
 }
 
-function whiteSpacedKeyword (prefix, suffix, aliasAsWord = true) {
-  let prefix_bit = caseInsensitive(prefix, false)
-  let suffix_bit = caseInsensitive(suffix, false)
-  let both_bits = caseInsensitive(prefix + suffix, false)
-  if (aliasAsWord) {
-    prefix_bit = alias(prefix_bit, prefix)
-    suffix_bit = alias(suffix_bit, suffix)
-    both_bits = alias(both_bits, prefix + suffix)
-  }
+
+function whiteSpacedKeyword (prefix, suffix) {
+  let prefix_bit = caseInsensitive(prefix)
+  let suffix_bit = caseInsensitive(suffix)
+  let both_bits = caseInsensitive(prefix + suffix)
   return choice(
     seq(prefix_bit, suffix_bit),
     both_bits
@@ -2453,9 +2454,9 @@ function sep1 (rule, separator) {
 // with optional rule for labels/names, and with optional end-of-statement
 function blockStructureEnding1 ($, structType, labelRule=null) {
   // just listing all combinations looks easier to read
-  const end      = alias(caseInsensitive('end', false), 'end');
-  const strt     = alias(caseInsensitive(structType, false), structType);
-  const end_strt = alias(caseInsensitive('end' + structType, false), 'end' + structType);
+  const end      = caseInsensitive('end');
+  const strt     = caseInsensitive(structType);
+  const end_strt = caseInsensitive('end' + structType);
 
   const obj_end_stmt = choice(
     // when structure keyword is present, allow the label
@@ -2473,12 +2474,12 @@ function blockStructureEnding1 ($, structType, labelRule=null) {
 // 'end', 'end block' and 'end block data', with or without white spaces,
 // with optional rule for labels/names, and with optional end-of-statement
 function blockStructureEnding2 ($, structType1, structType2, labelRule=null, require_blank=false) {
-  const end          = alias(caseInsensitive('end', false), 'end');
-  const strt_1       = alias(caseInsensitive(structType1, false), structType1);
-  const strt_2       = alias(caseInsensitive(structType2, false), structType2);
-  const strt_1_2     = alias(caseInsensitive(structType1 + structType2, false), structType1 + structType2);
-  const end_strt_1   = alias(caseInsensitive('end' + structType1, false), 'end' + structType1);
-  const end_strt_1_2 = alias(caseInsensitive('end' + structType1 + structType2, false), 'end' + structType1 + structType2);
+  const end          = caseInsensitive('end');
+  const strt_1       = caseInsensitive(structType1);
+  const strt_2       = caseInsensitive(structType2);
+  const strt_1_2     = caseInsensitive(structType1 + structType2);
+  const end_strt_1   = caseInsensitive('end' + structType1);
+  const end_strt_1_2 = caseInsensitive('end' + structType1 + structType2);
 
 
   let obj_end_stmt;

--- a/grammar.js
+++ b/grammar.js
@@ -1997,7 +1997,9 @@ module.exports = grammar({
           field('right', $._expression)
         ))
       }).concat(
-        [prec.left(PREC.LOGICAL_NOT, seq(caseInsensitive('.not.'), $._expression))])
+        [prec.left(PREC.LOGICAL_NOT, seq(
+          field('operator', caseInsensitive('.not.')),
+          field('argument', $._expression)))])
       )
     },
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -120,15 +120,15 @@
  ] @operator
 
 [
- "\\.and\\."
- "\\.or\\."
- "\\.lt\\."
- "\\.gt\\."
- "\\.ge\\."
- "\\.le\\."
- "\\.eq\\."
- "\\.eqv\\."
- "\\.neqv\\."
+ ".and."
+ ".or."
+ ".lt."
+ ".gt."
+ ".ge."
+ ".le."
+ ".eq."
+ ".eqv."
+ ".neqv."
  ] @keyword.operator
 
 ;; Brackets

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -11488,13 +11488,8 @@
                       {
                         "type": "ALIAS",
                         "content": {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "PATTERN",
-                            "value": "[sS][eE][qQ][uU][eE][nN][cC][eE]"
-                          },
-                          "named": false,
-                          "value": "sequence"
+                          "type": "PATTERN",
+                          "value": "[sS][eE][qQ][uU][eE][nN][cC][eE]"
                         },
                         "named": true,
                         "value": "sequence_statement"
@@ -17402,13 +17397,8 @@
             {
               "type": "ALIAS",
               "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[dD][eE][fF][aA][uU][lL][tT]"
-                },
-                "named": false,
-                "value": "default"
+                "type": "PATTERN",
+                "value": "[dD][eE][fF][aA][uU][lL][tT]"
               },
               "named": true,
               "value": "default"
@@ -17580,13 +17570,8 @@
                 {
                   "type": "ALIAS",
                   "content": {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[dD][eE][fF][aA][uU][lL][tT]"
-                    },
-                    "named": false,
-                    "value": "default"
+                    "type": "PATTERN",
+                    "value": "[dD][eE][fF][aA][uU][lL][tT]"
                   },
                   "named": true,
                   "value": "default"
@@ -17718,13 +17703,8 @@
               {
                 "type": "ALIAS",
                 "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[dD][eE][fF][aA][uU][lL][tT]"
-                  },
-                  "named": false,
-                  "value": "default"
+                  "type": "PATTERN",
+                  "value": "[dD][eE][fF][aA][uU][lL][tT]"
                 },
                 "named": true,
                 "value": "default"
@@ -20016,7 +19996,7 @@
                     "value": "\\.[oO][rR]\\."
                   },
                   "named": false,
-                  "value": "\\.or\\."
+                  "value": ".or."
                 }
               },
               {
@@ -20054,7 +20034,7 @@
                     "value": "\\.[aA][nN][dD]\\."
                   },
                   "named": false,
-                  "value": "\\.and\\."
+                  "value": ".and."
                 }
               },
               {
@@ -20092,7 +20072,7 @@
                     "value": "\\.[eE][qQ][vV]\\."
                   },
                   "named": false,
-                  "value": "\\.eqv\\."
+                  "value": ".eqv."
                 }
               },
               {
@@ -20130,7 +20110,7 @@
                     "value": "\\.[nN][eE][qQ][vV]\\."
                   },
                   "named": false,
-                  "value": "\\.neqv\\."
+                  "value": ".neqv."
                 }
               },
               {
@@ -20151,17 +20131,25 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "ALIAS",
+                "type": "FIELD",
+                "name": "operator",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "\\.[nN][oO][tT]\\."
-                },
-                "named": false,
-                "value": "\\.not\\."
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "\\.[nN][oO][tT]\\."
+                  },
+                  "named": false,
+                  "value": ".not."
+                }
               },
               {
-                "type": "SYMBOL",
-                "name": "_expression"
+                "type": "FIELD",
+                "name": "argument",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
               }
             ]
           }
@@ -20228,7 +20216,7 @@
                     "value": "\\.[lL][tT]\\."
                   },
                   "named": false,
-                  "value": "\\.lt\\."
+                  "value": ".lt."
                 }
               },
               {
@@ -20299,7 +20287,7 @@
                     "value": "\\.[gG][tT]\\."
                   },
                   "named": false,
-                  "value": "\\.gt\\."
+                  "value": ".gt."
                 }
               },
               {
@@ -20370,7 +20358,7 @@
                     "value": "\\.[lL][eE]\\."
                   },
                   "named": false,
-                  "value": "\\.le\\."
+                  "value": ".le."
                 }
               },
               {
@@ -20441,7 +20429,7 @@
                     "value": "\\.[gG][eE]\\."
                   },
                   "named": false,
-                  "value": "\\.ge\\."
+                  "value": ".ge."
                 }
               },
               {
@@ -20512,7 +20500,7 @@
                     "value": "\\.[eE][qQ]\\."
                   },
                   "named": false,
-                  "value": "\\.eq\\."
+                  "value": ".eq."
                 }
               },
               {
@@ -20583,7 +20571,7 @@
                     "value": "\\.[nN][eE]\\."
                   },
                   "named": false,
-                  "value": "\\.ne\\."
+                  "value": ".ne."
                 }
               },
               {
@@ -21532,7 +21520,7 @@
                 "value": "\\.[tT][rR][uU][eE]\\."
               },
               "named": false,
-              "value": "\\.true\\."
+              "value": ".true."
             },
             {
               "type": "ALIAS",
@@ -21541,7 +21529,7 @@
                 "value": "\\.[fF][aA][lL][sS][eE]\\."
               },
               "named": false,
-              "value": "\\.false\\."
+              "value": ".false."
             }
           ]
         },
@@ -22491,7 +22479,7 @@
         "value": "\\.[nN][iI][lL]\\."
       },
       "named": false,
-      "value": "\\.nil\\."
+      "value": ".nil."
     },
     "identifier": {
       "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3888,6 +3888,16 @@
     "type": "logical_expression",
     "named": true,
     "fields": {
+      "argument": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
       "left": {
         "multiple": false,
         "required": false,
@@ -3900,22 +3910,26 @@
       },
       "operator": {
         "multiple": false,
-        "required": false,
+        "required": true,
         "types": [
           {
-            "type": "\\.and\\.",
+            "type": ".and.",
             "named": false
           },
           {
-            "type": "\\.eqv\\.",
+            "type": ".eqv.",
             "named": false
           },
           {
-            "type": "\\.neqv\\.",
+            "type": ".neqv.",
             "named": false
           },
           {
-            "type": "\\.or\\.",
+            "type": ".not.",
+            "named": false
+          },
+          {
+            "type": ".or.",
             "named": false
           }
         ]
@@ -3930,16 +3944,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "_expression",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -5751,6 +5755,30 @@
         "required": true,
         "types": [
           {
+            "type": ".eq.",
+            "named": false
+          },
+          {
+            "type": ".ge.",
+            "named": false
+          },
+          {
+            "type": ".gt.",
+            "named": false
+          },
+          {
+            "type": ".le.",
+            "named": false
+          },
+          {
+            "type": ".lt.",
+            "named": false
+          },
+          {
+            "type": ".ne.",
+            "named": false
+          },
+          {
             "type": "/=",
             "named": false
           },
@@ -5772,30 +5800,6 @@
           },
           {
             "type": ">=",
-            "named": false
-          },
-          {
-            "type": "\\.eq\\.",
-            "named": false
-          },
-          {
-            "type": "\\.ge\\.",
-            "named": false
-          },
-          {
-            "type": "\\.gt\\.",
-            "named": false
-          },
-          {
-            "type": "\\.le\\.",
-            "named": false
-          },
-          {
-            "type": "\\.lt\\.",
-            "named": false
-          },
-          {
-            "type": "\\.ne\\.",
             "named": false
           }
         ]
@@ -7095,6 +7099,62 @@
     "named": false
   },
   {
+    "type": ".and.",
+    "named": false
+  },
+  {
+    "type": ".eq.",
+    "named": false
+  },
+  {
+    "type": ".eqv.",
+    "named": false
+  },
+  {
+    "type": ".false.",
+    "named": false
+  },
+  {
+    "type": ".ge.",
+    "named": false
+  },
+  {
+    "type": ".gt.",
+    "named": false
+  },
+  {
+    "type": ".le.",
+    "named": false
+  },
+  {
+    "type": ".lt.",
+    "named": false
+  },
+  {
+    "type": ".ne.",
+    "named": false
+  },
+  {
+    "type": ".neqv.",
+    "named": false
+  },
+  {
+    "type": ".nil.",
+    "named": false
+  },
+  {
+    "type": ".not.",
+    "named": false
+  },
+  {
+    "type": ".or.",
+    "named": false
+  },
+  {
+    "type": ".true.",
+    "named": false
+  },
+  {
     "type": "/",
     "named": false
   },
@@ -7176,62 +7236,6 @@
   },
   {
     "type": "[",
-    "named": false
-  },
-  {
-    "type": "\\.and\\.",
-    "named": false
-  },
-  {
-    "type": "\\.eq\\.",
-    "named": false
-  },
-  {
-    "type": "\\.eqv\\.",
-    "named": false
-  },
-  {
-    "type": "\\.false\\.",
-    "named": false
-  },
-  {
-    "type": "\\.ge\\.",
-    "named": false
-  },
-  {
-    "type": "\\.gt\\.",
-    "named": false
-  },
-  {
-    "type": "\\.le\\.",
-    "named": false
-  },
-  {
-    "type": "\\.lt\\.",
-    "named": false
-  },
-  {
-    "type": "\\.ne\\.",
-    "named": false
-  },
-  {
-    "type": "\\.neqv\\.",
-    "named": false
-  },
-  {
-    "type": "\\.nil\\.",
-    "named": false
-  },
-  {
-    "type": "\\.not\\.",
-    "named": false
-  },
-  {
-    "type": "\\.or\\.",
-    "named": false
-  },
-  {
-    "type": "\\.true\\.",
     "named": false
   },
   {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -594,115 +594,115 @@ END PROGRAM
     (program_statement
       (name))
     (assignment_statement
-      (identifier)
-      (relational_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (relational_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (relational_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (relational_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (relational_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (relational_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (relational_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (relational_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (relational_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (relational_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (relational_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (relational_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (relational_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (relational_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (relational_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (relational_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (relational_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (relational_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (relational_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (relational_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (relational_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (relational_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (relational_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (relational_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (logical_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (logical_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (logical_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (logical_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (logical_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (logical_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (logical_expression
-        (identifier)
-        (identifier)))
+      left: (identifier)
+      right: (logical_expression
+        left: (identifier)
+        right: (identifier)))
     (assignment_statement
-      (identifier)
-      (logical_expression
-        (identifier)))
+      left: (identifier)
+      right: (logical_expression
+        argument: (identifier)))
     (assignment_statement
-      (identifier)
-      (parenthesized_expression
+      left: (identifier)
+      right: (parenthesized_expression
         (logical_expression
-          (relational_expression
-            (identifier)
-            (identifier)))))
+          argument: (relational_expression
+            left: (identifier)
+            right: (identifier)))))
     (assignment_statement
-      (identifier)
-      (logical_expression
-        (parenthesized_expression
+      left: (identifier)
+      right: (logical_expression
+        left: (parenthesized_expression
           (logical_expression
-            (parenthesized_expression
+            left: (parenthesized_expression
               (relational_expression
-                (identifier)
-                (identifier)))
-            (parenthesized_expression
+                left: (identifier)
+                right: (identifier)))
+            right: (parenthesized_expression
               (relational_expression
-                (identifier)
-                (identifier)))))
-        (boolean_literal)))
+                left: (identifier)
+                right: (identifier)))))
+        right: (boolean_literal)))
     (assignment_statement
-      (identifier)
-      (relational_expression
-        (number_literal)
-        (number_literal)))
+      left: (identifier)
+      right: (relational_expression
+        left: (number_literal)
+        right: (number_literal)))
     (end_program_statement)))
 
 ================================================================================


### PR DESCRIPTION
In contrast to all other operators, the rule for .not. did not use field names. The field name for the argument is 'argument', which is also used at other unary operator rules, see $.unary_expression.

This is intended for queries in conjunction with indentation/alignment of multiline logical expression, which become more complex if single operators needs to be matched.

This change as far as I can see, cannot be covered by current test capabilities?

PS: This is tested with 0.25.10, but updates by 'npm run generate' are not yet included.