### PR TITLE
Fix queries

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,110 +1,115 @@
-(identifier) @variable
+[
+ (identifier)
+ (module_name)
+] @variable
+
 (string_literal) @string
 (number_literal) @number
+(statement_label) @number
+(statement_label_reference) @number
 (boolean_literal) @boolean
 (comment) @comment
 (custom_directive) @custom_directive
 
 [
+ (derived_type)
+ (derived_type_statement)
+ (import_statement)
  (intrinsic_type)
- "allocatable"
- "attributes"
- "device"
- "dimension"
- "endtype"
- "global"
- "grid_global"
- "host"
- "import"
- "in"
- "inout"
- "intent"
- "optional"
- "out"
- "pointer"
- "type"
- "value"
- ] @type
+ (type_name)
+] @type
+
+(intrinsic_type) @type.builtin
+
+(base_type_specifier
+  (identifier) @type)
 
 [
- "contains"
- "private"
- "public"
- ] @include
+ (module_statement)
+ (submodule_statement)
+] @module
 
 [
+ (abstract_specifier)
+ (access_specifier)
+ (block_label)
+ (block_label_start_expression)
  (none)
- "implicit"
- ] @attribute
-
-[
- "endfunction"
- "endprogram"
- "endsubroutine"
- "function"
- "procedure"
- "subroutine"
- ] @keyword.function
-
-[
- (default)
+ (procedure_attributes)
  (procedure_qualifier)
- "abstract"
- "bind"
- "call"
- "class"
- "continue"
- "cycle"
- "endenum"
- "endinterface"
- "endmodule"
- "endprocedure"
- "endprogram"
- "endsubmodule"
- "enum"
- "enumerator"
- "equivalence"
- "exit"
- "extends"
- "format"
- "goto"
- "include"
- "interface"
- "intrinsic"
- "non_intrinsic"
- "module"
- "namelist"
- "only"
- "parameter"
- "print"
- "procedure"
- "program"
- "read"
- "stop"
- "submodule"
- "use"
- "write"
- ] @keyword
-
-"return" @keyword.return
+ (type_qualifier)
+] @attribute
 
 [
- "else"
- "elseif"
- "elsewhere"
- "endif"
- "endwhere"
- "if"
- "then"
- "where"
- ] @conditional
+ "#define"
+ "#elif"
+ "#endif"
+ "#if"
+ "#ifdef"
+ (base_type_specifier)
+ (block_construct)
+ (contains_statement)
+ (default)
+ (end_associate_statement)
+ (end_block_construct_statement)
+ (end_block_data_statement)
+ (end_coarray_critical_statement)
+ (end_coarray_team_statement)
+ (end_do_loop_statement)
+ (end_enum_statement)
+ (end_enumeration_type_statement)
+ (end_forall_statement)
+ (end_function_statement)
+ (end_if_statement)
+ (end_interface_statement)
+ (end_module_procedure_statement)
+ (end_module_statement)
+ (end_program_statement)
+ (end_select_statement)
+ (end_submodule_statement)
+ (end_subroutine_statement)
+ (end_type_statement)
+ (end_where_statement)
+ (enum_statement)
+ (enumeration_type_statement)
+ (enumerator_statement)
+ (equivalence_statement)
+ (function_statement)
+ (implicit_statement)
+ (interface_statement)
+ (keyword_statement)
+ (language_binding)
+ (namelist_statement)
+ (print_statement)
+ (procedure_statement)
+ (program_statement)
+ (subroutine_statement)
+] @keyword
 
-[
- "do"
- "enddo"
- "forall"
- "while"
- ] @repeat
+(use_statement "use" @keyword)
+(use_statement "intrinsic" @keyword)
+(included_items "only" @keyword)
+(allocate_statement "allocate" @keyword)
+(deallocate_statement "deallocate" @keyword)
+(subroutine_call "call" @keyword)
+(do_statement "do" @keyword)
+(while_statement "while" @keyword)
+(if_statement ["if" "then"] @keyword)
+(elseif_clause ["else" "if" "elseif"] @keyword)
+(else_clause "else" @keyword)
+(open_statement "open" @keyword)
+(write_statement "write" @keyword)
+(private_statement "private" @keyword)
+(public_statement "public" @keyword)
+
+
+(select_case_statement "select" @keyword "case" @keyword)
+(select_type_statement "select" @keyword "type" @keyword)
+(select_rank_statement "select" @keyword "rank" @keyword)
+(case_statement "case" @keyword)
+(type_statement "type" @keyword)
+(rank_statement "rank" @keyword)
+
 
 [
  "*"
@@ -118,9 +123,6 @@
  ">="
  "=="
  "/="
- ] @operator
-
-[
  ".and."
  ".or."
  ".lt."
@@ -130,7 +132,8 @@
  ".eq."
  ".eqv."
  ".neqv."
- ] @keyword.operator
+ ".ne."
+] @operator
 
 ;; Brackets
 [
@@ -140,26 +143,29 @@
  "]"
  "<<<"
  ">>>"
- ] @punctuation.bracket
+] @punctuation.bracket
 
 ;; Delimiter
 [
  "::"
  ","
  "%"
- ] @punctuation.delimiter
+ ":"
+] @punctuation.delimiter
+
+"&" @punctuation.special
 
 (parameters
-  (identifier) @parameter)
+  (identifier) @variable.parameter)
 
 (program_statement
-  (name) @namespace)
+  (name) @variable)
 
 (module_statement
-  (name) @namespace)
+  (name) @variable)
 
 (submodule_statement
-  (module_name) (name) @namespace)
+  (module_name) (name) @variable)
 
 (function_statement
   (name) @function)
@@ -171,13 +177,13 @@
   (name) @function)
 
 (end_program_statement
-  (name) @namespace)
+  (name) @variable)
 
 (end_module_statement
-  (name) @namespace)
+  (name) @variable)
 
 (end_submodule_statement
-  (name) @namespace)
+  (name) @variable)
 
 (end_function_statement
   (name) @function)
@@ -196,6 +202,3 @@
 
 (derived_type_member_expression
   (type_member) @property)
-
-(call_expression
-  (identifier) @function.call)

--- a/queries/locals.scm
+++ b/queries/locals.scm
@@ -1,0 +1,10 @@
+(derived_type_definition) @local.scope
+(program) @local.scope
+(module) @local.scope
+(submodule) @local.scope
+(interface) @local.scope
+(function) @local.scope
+(subroutine) @local.scope
+(block_construct) @local.scope
+
+(variable_declaration declarator: (identifier) @local.definition)

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,0 +1,42 @@
+(derived_type_statement
+  (type_name) @name) @definition.class
+
+(base_type_specifier
+  (identifier) @name) @reference.class
+
+(program_statement
+  (name) @name) @definition.module
+
+(module_statement
+  (name) @name) @definition.module
+
+(submodule_statement
+  (module_name) (name) @name) @definition.module
+
+(interface
+ (function
+   (function_statement
+    (name) @name) @definition.interface))
+
+(interface
+ (subroutine
+   (subroutine_statement
+    (name) @name) @definition.interface))
+
+(function_statement
+  (name) @name) @definition.function
+
+(subroutine_statement
+  (name) @name) @definition.function
+
+(module_procedure_statement
+  (name) @name) @reference.implementation
+
+(call_expression
+  (identifier) @name) @reference.call
+
+(subroutine_call
+  (identifier) @name) @reference.call
+
+(derived_type
+   (type_name) @name) @reference.class

--- a/test/highlight/blocks.f90
+++ b/test/highlight/blocks.f90
@@ -1,0 +1,31 @@
+program block_demo
+  ! <- keyword
+  !      ^ variable
+  implicit none
+  ! <- keyword
+  !        ^ attribute
+  real :: y = 1
+  ! <- type.builtin
+  !    ^ punctuation.delimiter
+  !       ^ variable
+  print *, y
+  ! <- keyword
+  !        ^ !variable
+  block
+    ! <- keyword
+    real :: x = 3.142
+    ! <- type.builtin
+    !       ^ variable
+    !            ^ number
+    print *, x
+    y = x
+    inner: block
+      ! <- attribute
+      real :: y = 12.1
+      print *, y
+    end block inner
+    ! <- keyword
+    !         ^ attribute
+  end block
+  print *, y
+end program block_demo

--- a/test/highlight/constructs.f90
+++ b/test/highlight/constructs.f90
@@ -1,0 +1,103 @@
+PROGRAM TEST
+  implicit none
+  integer :: x, y, i, j
+  character(len=5) :: arg
+  ! <- type.builtin
+  !             ^ number
+
+  IF (x < 7) y = 9
+  ! <- keyword
+  !   ^ variable
+  !     ^ operator
+  !        ^ punctuation.bracket
+  !          ^ variable
+  !               ^ number
+
+  if(x > 1 .and. 2 <= x) x = 4
+  ! <- keyword
+  !    ^ operator
+  !      ^ number
+  !         ^ operator
+  !              ^ number
+  !                ^ operator
+
+  IF (arg(1:1) == ADJUSTL(' r')) THEN
+  ! <- keyword
+  !                        ^ string
+  !                               ^ keyword
+    x = 0
+  ELSE IF (arg(1:1) .NE. CHAR(x)) THEN
+    ! <- keyword
+    !  ^ keyword
+    !                ^ operator
+    !                               ^ keyword
+    x = 2
+  elseif (arg(1:1) /= "x") then
+    ! <- keyword
+    !                       ^ keyword
+    x = 3
+  ELSE
+    ! <- keyword
+    x = 4
+  ENDIF
+  ! <- keyword
+
+  do i = 1, 10
+  ! <- keyword
+    x = 6**x
+    OPEN(i, FILE="qwerty")
+    ! <- keyword
+    !    ^ variable
+    !              ^ string
+    CALL MYSUB(i, .TRUE.)
+    ! <- keyword
+    !                ^ boolean
+  end do
+  ! <- keyword
+  !    ^ keyword
+
+  DO i = 1, 10
+    CONTINUE
+    ! <- keyword
+  ENDDO
+  ! <- keyword
+
+  out44: DO i = 1,INT(SIN(9.0*i))
+    ! <- attribute
+    DO WHILE (.false.)
+     ! <- keyword
+     ! ^ keyword
+     !        ^ boolean
+      cycle out44
+      ! <- keyword
+      !      ^ attribute
+    END DO
+    ! <- keyword
+    !   ^ keyword
+  enddo out44
+  ! <- keyword
+  !      ^ attribute
+
+  do i = 1, 10
+    if (.true.) go to 100
+    !                  ^ number
+100 end do
+! <- number
+
+  SELECT CASE (c)
+    ! <- keyword
+    !      ^ keyword
+    !          ^ variable
+  CASE ('a' : 'm', 'n' : 'z')
+    ! <- keyword
+    !       ^ punctuation.delimiter
+    WRITE(*,*) 'lowercase letter'
+  CASE ('A' : 'Z')
+    WRITE(*,*) 'uppercase letter'
+  CASE (WILDCARD_CHAR)
+    WRITE(*,*) 'wildcard letter'
+  CASE DEFAULT
+    WRITE(*,*)  'Other characters, which may not be letters'
+  END SELECT
+
+END PROGRAM TEST

--- a/test/highlight/keyword_clashes.f90
+++ b/test/highlight/keyword_clashes.f90
@@ -1,0 +1,33 @@
+program demo
+   integer :: endif, if, elseif, error
+   integer, DIMENSION(2) :: function
+   endif = 3; if = 2
+   ! <- variable
+   error = 1
+   ! <- variable
+   if (endif == 2) then
+        ! <- variable
+      endif = 5
+      ! <- variable
+      elseif = if + endif
+        ! <- variable
+        !      ^ variable
+        !            ^ variable
+   elseif (endif == 3) then
+      function(if) = endif/elseif
+      ! <- variable
+      !               ^ variable
+      !                     ^ variable
+      print *, endif
+   endif
+end program
+
+subroutine foo
+  integer :: if(1), elseif, else
+  character(len=32) :: format
+  character(len=1) :: width
+  format(7:9) = width//'.'//width
+  ! <- variable
+  if(1) = 5
+  ! <- variable
+end subroutine foo

--- a/test/highlight/module_with_interface.f90
+++ b/test/highlight/module_with_interface.f90
@@ -1,0 +1,45 @@
+MODULE BoundingBox_Method
+  ! <- module
+  !     ^ variable
+  use other_module, only : foo
+  ! <- keyword
+  !     ^ variable
+  !                  ^ keyword
+  !                         ^ variable
+  use, intrinsic :: iso_c_binding, only : real64
+  ! <- keyword
+  !     ^ keyword
+  !                  ^ variable
+
+  PRIVATE
+  ! <- keyword
+  public :: initiate_1, constructor_2
+  ! <- keyword
+  !           ^ variable
+  INTERFACE
+    ! <- keyword
+    MODULE PURE SUBROUTINE initiate_1(obj, nsd, lim)
+      ! <- attribute
+      !     ^ attribute
+      !          ^ keyword
+      !                     ^ function
+      !                                ^ variable.parameter
+      CLASS(BoundingBox_), INTENT(INOUT) :: obj
+      ! <- type
+      !      ^ type
+      !                     ^ attribute
+      !                            ^ attribute
+      !                                     ^ variable
+    END SUBROUTINE initiate_1
+    ! ^ keyword
+  END INTERFACE
+
+  INTERFACE
+    MODULE FUNCTION Constructor_2(Anotherobj) RESULT(Ans)
+      CLASS(BoundingBox_), POINTER :: Ans
+      ! <- type
+      !      ^ type
+      !                     ^ attribute
+    END FUNCTION Constructor_2
+  END INTERFACE
+END MODULE BoundingBox_Method

--- a/test/highlight/types.f90
+++ b/test/highlight/types.f90
@@ -1,0 +1,18 @@
+module test
+  ! <- module
+  !     ^ variable
+  type, private, abstract :: abstract_type
+    ! <- type
+    !    ^ attribute
+    !             ^ attribute
+    !                         ^ type
+  end type abstract_type
+  ! <- keyword
+  !         ^ type
+  type, public, extends(abstract_type) :: concrete_type
+    ! <- type
+    !    ^ attribute
+    !             ^ keyword
+    !                         ^ type
+  end type concrete_type
+end module

--- a/test/tags/module_with_interface.f90
+++ b/test/tags/module_with_interface.f90
@@ -1,0 +1,40 @@
+module BoundingBox_Method
+  !     ^ definition.module
+  implicit none (type, external)
+
+  type, private, abstract :: abstract_type
+    !                         ^ definition.class
+  end type abstract_type
+  type, public, extends(abstract_type) :: concrete_type
+    !                         ^ reference.class
+    !                                       ^ definition.class
+  end type concrete_type
+
+  interface
+    module pure subroutine initiate_1(obj)
+      !                     ^ definition.interface
+      integer, intent(inout) :: obj
+    end subroutine initiate_1
+  end interface
+
+  interface
+    module function constructor_2(anotherobj) result(ans)
+      !              ^ definition.interface
+      class(concrete_type) :: anotherobj
+      !       ^ reference.class
+      integer :: Ans
+    end function constructor_2
+  end interface
+
+contains
+  module procedure initiate_1
+  !                 ^ reference.implementation
+  end procedure initiate_1
+
+  module procedure constructor_2
+  !                 ^ reference.implementation
+    call initiate_1(ans)
+    !     ^ reference.call
+  end procedure constructor_2
+
+END MODULE BoundingBox_Method

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -14,6 +14,9 @@
       "highlights": [
         "queries/highlights.scm"
       ],
+      "tags": [
+        "queries/tags.scm"
+      ],
       "injection-regex": "fortran"
     }
   ],


### PR DESCRIPTION
Fix the highlight queries for the latest grammar:

- Add lots of missing nodes
- Distinguish between keywords and identifiers (Fortran's non-reserved keyword problem)
- Add `tags.scm`

@mscfd Is this useful for the emacs ts-mode? I know `font-lock` uses different names, but can you just replace the names?