### PR TITLE
Add rank(*) to rank_statement

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1651,6 +1651,7 @@ module.exports = grammar({
       caseInsensitive('rank'),
       choice(
         seq('(', $.case_value_range_list, ')'),
+        seq('(', $.assumed_size, ')'),
         alias(caseInsensitive('default'), $.default)
       ),
       optional($._block_label),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -17699,6 +17699,23 @@
                 ]
               },
               {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "("
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "assumed_size"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ")"
+                  }
+                ]
+              },
+              {
                 "type": "ALIAS",
                 "content": {
                   "type": "ALIAS",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5659,6 +5659,10 @@
           "named": true
         },
         {
+          "type": "assumed_size",
+          "named": true
+        },
+        {
           "type": "block_label",
           "named": true
         },

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -2317,6 +2317,11 @@ subroutine assumed_rank(A)
     rank default
       error stop 'assumed_rank: only rank 0..2 is handled for now.'
   end select
+
+  check_assumed_size: select rank(A)
+    rank (*) check_assumed_size
+      write(*, *) "assumed_rank: assumed size array not supported"
+  end select check_assumed_size
 end subroutine assumed_rank
 
 --------------------------------------------------------------------------------
@@ -2366,6 +2371,20 @@ end subroutine assumed_rank
         (stop_statement
           (string_literal)))
       (end_select_statement))
+    (select_rank_statement
+      (block_label_start_expression)
+      (selector
+        (identifier))
+      (rank_statement
+        (assumed_size)
+        (block_label)
+        (write_statement
+          (unit_identifier)
+          (format_identifier)
+          (output_item_list
+            (string_literal))))
+      (end_select_statement
+        (block_label)))
     (end_subroutine_statement
       (name))))
 


### PR DESCRIPTION
The commit adds `rank(*)` for assumed-sized arrays to the select rank statement. An existing select rank test in test/corpus/statements.txt has been extended to test the `rank(*)` rule.