### PR TITLE
Fix UB when when accesing last element of stack in scanner

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -458,10 +458,12 @@ static bool scan_preproc_unary_operator(TSLexer *lexer) {
 
 static void track_labeled_do(Scanner *scanner, int32_t label) {
     // check if label already exists
-    int i = scanner->depth - 1;
-    if (scanner->labels[i] == label) {
+    if (scanner->depth > 0) {
+      int i = scanner->depth - 1;
+      if (scanner->labels[i] == label) {
         scanner->counts[i]++;
         return;
+      }
     }
 
     // not at top of stack, assume new label, add it to stack


### PR DESCRIPTION
The array is accessed with index -1. Not sure if/how to leave a test with this. You can test it yourself:
```
! test.f90
program p
  do 10 i = 1,10
  10 continue
end
```
```
$ CC="gcc" CFLAGS="-fsanitize=undefined" node_modules/tree-sitter-cli/tree-sitter parse --rebuild test.f90

/tmp/tree-sitter-fortran/./src/scanner.c:462:24: runtime error: index -1 out of bounds for type 'int32_t [100]'
```