### PR TITLE
Parse parts, continuation and comments in string literals

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -64,6 +64,10 @@ module.exports = grammar({
     $._do_label,
     $.do_label_virtual,
     $._do_label_continue,
+    $.string_literal_start,
+    $.string_literal_part,
+    $.string_literal_quote,
+    $.string_literal_end,
   ],
 
   extras: $ => [
@@ -107,6 +111,7 @@ module.exports = grammar({
     [$.cray_pointer_declaration, $.identifier],
     [$.unit_identifier, $.identifier],
     [$.format_identifier, $.identifier],
+    [$._string_literal_content],
   ],
 
   supertypes: $ => [
@@ -2219,7 +2224,14 @@ module.exports = grammar({
         // also need to *capture* it here
         token.immediate('_'),
       )),
-      $._string_literal,
+      alias($.string_literal_start, '"'),
+      repeat($._string_literal_content),
+      alias($.string_literal_end, '"'),
+    ),
+
+    _string_literal_content: $ => seq(
+      optional(alias($.string_literal_quote, '\\')),
+      repeat1($.string_literal_part),
     ),
 
     // Coarrays

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -21703,8 +21703,58 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_string_literal"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "string_literal_start"
+          },
+          "named": false,
+          "value": "\""
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_string_literal_content"
+          }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "string_literal_end"
+          },
+          "named": false,
+          "value": "\""
+        }
+      ]
+    },
+    "_string_literal_content": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "string_literal_quote"
+              },
+              "named": false,
+              "value": "\\"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "SYMBOL",
+            "name": "string_literal_part"
+          }
         }
       ]
     },
@@ -23303,6 +23353,9 @@
     [
       "format_identifier",
       "identifier"
+    ],
+    [
+      "_string_literal_content"
     ]
   ],
   "precedences": [],
@@ -23354,6 +23407,22 @@
     {
       "type": "SYMBOL",
       "name": "_do_label_continue"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "string_literal_start"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "string_literal_part"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "string_literal_quote"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "string_literal_end"
     }
   ],
   "inline": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3029,6 +3029,16 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "string_literal_part",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -6123,6 +6133,16 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "string_literal_part",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -7006,6 +7026,10 @@
     "named": false
   },
   {
+    "type": "\"",
+    "named": false
+  },
+  {
     "type": "#define",
     "named": false
   },
@@ -7236,6 +7260,10 @@
   },
   {
     "type": "[",
+    "named": false
+  },
+  {
+    "type": "\\",
     "named": false
   },
   {
@@ -7783,11 +7811,11 @@
   },
   {
     "type": "none",
-    "named": true
+    "named": false
   },
   {
     "type": "none",
-    "named": false
+    "named": true
   },
   {
     "type": "nopass",
@@ -7980,6 +8008,10 @@
   {
     "type": "stop",
     "named": false
+  },
+  {
+    "type": "string_literal_part",
+    "named": true
   },
   {
     "type": "submodule",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -17,13 +17,36 @@ enum TokenType {
     DO_LABEL,
     DO_LABEL_VIRTUAL,
     DO_LABEL_CONTINUE,
+    STRING_LITERAL_START,
+    STRING_LITERAL_PART,
+    STRING_LITERAL_QUOTE,
+    STRING_LITERAL_END
 };
 
 // at most 100 nested labeled do loops, should be sufficient
 #define MAX_LABEL_STACK 100
 
+// states for parsing strings, which can be continued and spread over several lines,
+// with comments in between,
+// state IN_STRING_QUOTE_CONT is required to handle a double double/single quote
+// with ampersand in between:
+//   s = "abc"&
+//       &"def"
+// corresponding to string "abc""def" and content abc"def
+typedef enum {
+    IN_STRING_NONE = 0,
+    IN_STRING_NORMAL = 1,
+    IN_STRING_QUOTE_QUOTE = 2,
+} InStringState;
+
+
 typedef struct {
     bool in_line_continuation;
+
+    // scanner state for remembering that scanner is within a (possibly continued) string
+    InStringState in_string;
+    // opening quote to match the closing quote, both ' and " are possible
+    char string_quote;
 
     // stack for tracking active DO labels and their counts
     int32_t depth;
@@ -379,69 +402,205 @@ static bool scan_string_literal_kind(TSLexer *lexer) {
     return true;
 }
 
-static bool scan_string_literal(TSLexer *lexer) {
-    const char opening_quote = lexer->lookahead;
-
-    if (opening_quote != '"' && opening_quote != '\'') {
+static bool scan_string_literal_start(Scanner *scanner, TSLexer *lexer) {
+    if (lexer->lookahead != '"' && lexer->lookahead != '\'') {
         return false;
     }
-
+    scanner->string_quote = lexer->lookahead;
     advance(lexer);
-    lexer->result_symbol = STRING_LITERAL;
+    lexer->mark_end(lexer);
+    scanner->in_string = IN_STRING_NORMAL;
+    lexer->result_symbol = STRING_LITERAL_START;
+    return true;
+}
 
-    while (lexer->lookahead != '\n' && !lexer->eof(lexer)) {
-        // Handle line continuations: strictly speaking, we MUST have
-        // both trailing '&' on first line AND leading '&' on second
-        // line, though most compilers do accept string literals
-        // missing the second '&'. In practice, everyone does seem to
-        // include it.
+typedef enum {
+    AMPERSAND_CONTINUATION, // ampersand is a LINE_CONTINUATION
+    AMPERSAND_CONTENT       // ampersand is part of the string content
+} AmpersandKind;
 
-        // We need to handle this here because sometimes '&' is part
-        // of the literal and not a continuation marker, and otherwise
-        // the parser gets confused, especially if there's no
-        // whitespace before the '&' in the string
-
-        // The literal token will end up containing the line
-        // continuation as well as any blank or comment lines inside
-        // the quotes (yes, you can have comments _inside_ string
-        // literals if they contain a line continuation)
-        if (lexer->lookahead == '&') {
-            advance(lexer);
-            // Consume blanks up to the end of the line or non-blank
-            while (iswblank(lexer->lookahead)) {
-                advance(lexer);
-            }
-            // If we hit the end of the line, consume all whitespace,
-            // including new lines
-            if (lexer->lookahead == '\n' || lexer->lookahead == '\r') {
-                while (iswspace(lexer->lookahead)) {
-                    advance(lexer);
-                }
-            }
-            continue;
-        }
-
-        // If we hit the same kind of quote that opened this literal,
-        // check to see if there's two in a row, and if so, consume
-        // both of them
-        if (lexer->lookahead == opening_quote) {
-            advance(lexer);
-            // It was just one quote, so we've successfully reached
-            // the end of the literal. We also need to check that an
-            // escaped quote isn't split in half by a line
-            // continuation -- people do this!
-            lexer->mark_end(lexer);
-            skip_literal_continuation_sequence(lexer);
-            if (lexer->lookahead != opening_quote) {
-                return true;
-            }
-        }
+// Called after advancing past an '&' inside a string literal.
+// It consumes any trailing blanks and decides whether the '&' is a line
+// continuation marker or ordinary string content.
+// It does not set and advance the end marker.
+static bool string_ampersand_is_continuation(Scanner *scanner, TSLexer *lexer) {
+    while (iswblank(lexer->lookahead)) {
         advance(lexer);
     }
+    return (lexer->lookahead == '\n' || lexer->lookahead == '\r' ||
+            lexer->lookahead == '!'  || lexer->eof(lexer));
+}
 
-    // We hit the end of the line without an '&', so this is an
-    // unclosed string literal (an error)
-    return false;
+// Handles an '&' encountered while scanning string content (lexer->lookahead == '&').
+// Decides whether it is a line continuation or ordinary content and sets
+// scanner state and lexer->result_symbol accordingly.
+static AmpersandKind scan_string_ampersand(Scanner *scanner, TSLexer *lexer, bool has_content) {
+    if (has_content) {
+        // preserve what we have accumulated in case this '&' is a continuation
+        lexer->mark_end(lexer);
+    }
+    // speculatively consume '&' and go on peeking ahead to make a decision
+    advance(lexer);
+    if (!has_content) {
+        // either line continuation or a string part starting with &,
+        // in both cases we want to capture the ampersand, and we must do it
+        // before string_ampersand_is_continuation, which advances the lexer
+        lexer->mark_end(lexer);
+    }
+
+    if (string_ampersand_is_continuation(scanner, lexer)) {
+        if (has_content) {
+            // PART ends right before the '&' (already marked above);
+            // the continuation itself is picked up on the next call
+            lexer->result_symbol = STRING_LITERAL_PART;
+        } else {
+            // nothing accumulated yet, this is a continuation symbol,
+            // where we stopped scanning in the last iteration,
+            // emit LINE_CONTINUATION
+            scanner->in_line_continuation = true;
+            lexer->result_symbol = LINE_CONTINUATION;
+        }
+        return AMPERSAND_CONTINUATION;
+    }
+
+    // not a continuation: put '&' and any consumed blanks into content
+    lexer->mark_end(lexer);
+    return AMPERSAND_CONTENT;
+}
+
+static void scan_string_quote_ampersand(Scanner *scanner, TSLexer *lexer) {
+    // lock the token boundary right here (after the current quote)
+    lexer->mark_end(lexer);
+
+    // speculatively advance past the initial '&'
+    advance(lexer);
+
+    // skip whitespace, newlines, and comments on intermediate lines
+    while (true) {
+        if (iswblank(lexer->lookahead)) {
+            advance(lexer);
+        } else if (lexer->lookahead == '\r' || lexer->lookahead == '\n') {
+            advance(lexer);
+        } else if (lexer->lookahead == '!') {
+            while (lexer->lookahead != '\n' && lexer->lookahead != '\r' && !lexer->eof(lexer)) {
+                advance(lexer);
+            }
+        } else {
+            break;
+        }
+    }
+
+    // check for the optional matching ampersand on the continuation line
+    if (lexer->lookahead == '&') {
+        advance(lexer);
+        while (iswblank(lexer->lookahead)) {
+            advance(lexer);
+        }
+    }
+
+    // finally examine the lookahead target character after ampersand
+    // (or first non-blank character on line)
+    if (lexer->lookahead == scanner->string_quote) {
+        // it is an escaped quote split across line continuations.
+        // set to IN_STRING_QUOTE_QUOTE so the second quote emits as STRING_LITERAL_PART,
+        // we need to wait for the parser to consume the continued lines separately
+        scanner->in_string = IN_STRING_QUOTE_QUOTE;
+        lexer->result_symbol = STRING_LITERAL_QUOTE;
+    } else {
+        // it is an ordinary statement continuation following a closed string
+        scanner->in_string = IN_STRING_NONE;
+        scanner->string_quote = '\0';
+        lexer->result_symbol = STRING_LITERAL_END;
+    }
+    return;
+}
+
+// Called after looking ahead at a string_quote character and without any
+// content yet.
+// It always emits a token and succeeds, thus no explicit true/false
+// return value.
+// It resolve the four cases:
+// (1) doubled quote, scan second quote,
+// (2) doubled quote, scan first quote,
+// (3) ambiguous quote+& (needs extensive look ahead)
+// (4) unambiguous closing quote.
+static void scan_string_quote(Scanner *scanner, TSLexer *lexer) {
+    // Consume the quote character
+    advance(lexer);
+
+    if (scanner->in_string == IN_STRING_QUOTE_QUOTE) {
+        // we just consumed the second quote of a doubled quote (same-line or split)
+        lexer->mark_end(lexer);
+        scanner->in_string = IN_STRING_NORMAL;
+        lexer->result_symbol = STRING_LITERAL_PART;
+        return;
+    }
+
+    // doubled quote on the same line ("")
+    if (lexer->lookahead == scanner->string_quote) {
+        lexer->mark_end(lexer);
+        scanner->in_string = IN_STRING_QUOTE_QUOTE;
+        lexer->result_symbol = STRING_LITERAL_QUOTE;
+        return;
+    }
+
+    // quote followed by '&'
+    if (lexer->lookahead == '&') {
+        scan_string_quote_ampersand(scanner, lexer);
+        return;
+    }
+
+    // unambiguous closing quote
+    lexer->mark_end(lexer);
+    scanner->in_string = IN_STRING_NONE;
+    scanner->string_quote = '\0';
+    lexer->result_symbol = STRING_LITERAL_END;
+    return;
+}
+
+
+static bool scan_string_literal_content(Scanner *scanner, TSLexer *lexer) {
+    // precondition:
+    //    in_string == IN_STRING_NORMAL || in_string == IN_STRING_QUOTE_QUOTE,
+    //    valid_symbols[STRING_LITERAL_PART] and valid_symbols[STRING_LITERAL_QUOTE]
+
+    bool has_content = false;
+
+    while (!lexer->eof(lexer)) {
+        if (lexer->lookahead == '\n' || lexer->lookahead == '\r') {
+            // unterminated string line: only valid if we have accumulated
+            // content, the grammar will hopefully close the string via error
+            // recovery
+            lexer->result_symbol = STRING_LITERAL_PART;
+            return has_content;
+        } else if (lexer->lookahead == scanner->string_quote) {
+            if (has_content) {
+                // emit what we have so far and let the next call handle the quote
+                lexer->result_symbol = STRING_LITERAL_PART;
+                return true;
+            } else {
+                // nothing accumulated yet (has_content is false), advance past quote
+               // and then decide which case we have, but we always succeed
+               scan_string_quote(scanner, lexer);
+               return true;
+            }
+        } else if (lexer->lookahead == '&') {
+            if (scan_string_ampersand(scanner, lexer, has_content) == AMPERSAND_CONTINUATION) {
+                return true;
+            } else {
+                // return value was AMPERSAND_CONTENT
+                has_content = true;
+            }
+        } else {
+            advance(lexer);
+            lexer->mark_end(lexer);
+            has_content = true;
+        }
+    }
+
+    // EOF inside string: emit whatever we have.
+    lexer->result_symbol = STRING_LITERAL_PART;
+    return has_content;
 }
 
 /// Need an external scanner to catch '!' before its parsed as a comment
@@ -612,9 +771,18 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
         return true;
     }
 
-    if (valid_symbols[STRING_LITERAL]) {
-        if (scan_string_literal(lexer)) {
-            return true;
+    // skip string parsing if we are in a line continuation state
+    if (!scanner->in_line_continuation) {
+        if (scanner->in_string == IN_STRING_NORMAL || scanner->in_string == IN_STRING_QUOTE_QUOTE) {
+            if (valid_symbols[STRING_LITERAL_PART] || valid_symbols[STRING_LITERAL_QUOTE]) {
+                if (scan_string_literal_content(scanner, lexer)) {
+                    return true;
+                }
+            }
+        } else if (valid_symbols[STRING_LITERAL_START]) {
+            if (scan_string_literal_start(scanner, lexer)) {
+                return true;
+            }
         }
     }
 
@@ -658,7 +826,8 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
 void *tree_sitter_fortran_external_scanner_create() {
     Scanner *scanner = ts_calloc(1, sizeof(Scanner));
     scanner->in_line_continuation = false;
-    scanner->depth = 0;
+    scanner->in_string = IN_STRING_NONE;
+    scanner->string_quote = '\0';
     scanner->pending_label_virtual = 0;
     scanner->is_pending_eos_virtual = false;
     return scanner;
@@ -679,6 +848,12 @@ unsigned tree_sitter_fortran_external_scanner_serialize(void *payload,
     size_t size = 0;
 
     buffer[size] = (char)scanner->in_line_continuation;
+    size += 1;
+
+    buffer[size] = (char)scanner->in_string;
+    size += 1;
+
+    buffer[size] = scanner->string_quote;
     size += 1;
 
     memcpy(&buffer[size], &scanner->depth, sizeof(int32_t));
@@ -715,6 +890,12 @@ void tree_sitter_fortran_external_scanner_deserialize(void *payload,
     size_t size = 0;
 
     scanner->in_line_continuation = buffer[size];
+    size += 1;
+
+    scanner->in_string = (InStringState)buffer[size];
+    size += 1;
+
+    scanner->string_quote = buffer[size];
     size += 1;
 
     memcpy(&scanner->depth, &buffer[size], sizeof(int32_t));

--- a/test/corpus/constructs.txt
+++ b/test/corpus/constructs.txt
@@ -118,7 +118,8 @@ end module
             (identifier)
             (argument_list
               (number_literal)))
-          (string_literal))))
+          (string_literal
+            (string_literal_part)))))
     (comment)
     (variable_declaration
       (intrinsic_type
@@ -131,7 +132,8 @@ end module
             (identifier)
             (argument_list
               (number_literal)))
-          (string_literal))))
+          (string_literal
+            (string_literal_part)))))
     (comment)
     (variable_declaration
       (intrinsic_type
@@ -144,7 +146,8 @@ end module
             (identifier)
             (argument_list
               (number_literal)))
-          (string_literal))))
+          (string_literal
+            (string_literal_part)))))
     (comment)
     (public_statement
       (identifier))
@@ -539,7 +542,8 @@ END SUBROUTINE
         (identifier)
         (keyword_argument
           (identifier)
-          (string_literal))))
+          (string_literal
+            (string_literal_part)))))
     (end_subroutine_statement))
   (subroutine
     (subroutine_statement
@@ -550,7 +554,8 @@ END SUBROUTINE
     (subroutine_call
       (identifier)
       (argument_list
-        (string_literal)
+        (string_literal
+          (string_literal_part))
         (identifier)))
     (internal_procedures
       (contains_statement)
@@ -677,7 +682,8 @@ end function
         (identifier)
         (keyword_argument
           (identifier)
-          (string_literal))))
+          (string_literal
+            (string_literal_part)))))
     (end_function_statement))
   (function
     (function_statement
@@ -688,7 +694,8 @@ end function
         (identifier)
         (keyword_argument
           (identifier)
-          (string_literal))))
+          (string_literal
+            (string_literal_part)))))
     (end_function_statement))
   (function
     (function_statement
@@ -697,7 +704,8 @@ end function
         (identifier)
         (keyword_argument
           (identifier)
-          (string_literal)))
+          (string_literal
+            (string_literal_part))))
       (function_result
         (identifier)))
     (end_function_statement)))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -147,6 +147,8 @@ PROGRAM TEST
     sngl_qt = '''double single quotes'''
     dble_qt = "'single in double quotes'"
     sngl_qt = '"double in single quotes"'
+    three_dble_qt = """"""""
+    three_sngl_qt = ''''''''
 
     val = "one"//'two'//sngl_qt//dble_qt
 
@@ -161,46 +163,76 @@ END PROGRAM
     (program_statement
       (name))
     (assignment_statement
-      left: (identifier)
-      right: (string_literal))
+      (identifier)
+      (string_literal))
     (assignment_statement
-      left: (identifier)
-      right: (string_literal))
+      (identifier)
+      (string_literal
+        (string_literal_part)
+        (string_literal_part)
+        (string_literal_part)))
     (assignment_statement
-      left: (identifier)
-      right: (string_literal))
+      (identifier)
+      (string_literal))
     (assignment_statement
-      left: (identifier)
-      right: (string_literal))
+      (identifier)
+      (string_literal
+        (string_literal_part)
+        (string_literal_part)
+        (string_literal_part)))
     (assignment_statement
-      left: (identifier)
-      right: (string_literal))
+      (identifier)
+      (string_literal
+        (string_literal_part)
+        (string_literal_part)
+        (string_literal_part)))
     (assignment_statement
-      left: (identifier)
-      right: (string_literal))
+      (identifier)
+      (string_literal
+        (string_literal_part)
+        (string_literal_part)
+        (string_literal_part)))
     (assignment_statement
-      left: (identifier)
-      right: (string_literal))
+      (identifier)
+      (string_literal
+        (string_literal_part)))
     (assignment_statement
-      left: (identifier)
-      right: (string_literal))
+      (identifier)
+      (string_literal
+        (string_literal_part)))
     (assignment_statement
-      left: (identifier)
-      right: (concatenation_expression
-        left: (string_literal)
-        right: (concatenation_expression
-          left: (string_literal)
-          right: (concatenation_expression
-            left: (identifier)
-            right: (identifier)))))
+      (identifier)
+      (string_literal
+        (string_literal_part)
+        (string_literal_part)
+        (string_literal_part)))
     (assignment_statement
-      left: (identifier)
-      right: (string_literal
-        kind: (identifier)))
+      (identifier)
+      (string_literal
+        (string_literal_part)
+        (string_literal_part)
+        (string_literal_part)))
     (assignment_statement
-      left: (identifier)
-      right: (string_literal
-        kind: (number_literal)))
+      (identifier)
+      (concatenation_expression
+        (string_literal
+          (string_literal_part))
+        (concatenation_expression
+          (string_literal
+            (string_literal_part))
+          (concatenation_expression
+            (identifier)
+            (identifier)))))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (identifier)
+        (string_literal_part)))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (number_literal)
+        (string_literal_part)))
     (end_program_statement)))
 
 ================================================================================
@@ -768,7 +800,8 @@ END PROGRAM
         (number_literal))
       (keyword_argument
         name: (identifier)
-        value: (string_literal)))
+        value: (string_literal
+          (string_literal_part))))
     (assignment_statement
       left: (derived_type_member_expression
         (identifier)
@@ -859,10 +892,12 @@ end program
     (write_statement
       (unit_identifier)
       (format_identifier
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (keyword_argument
         (identifier)
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (comment)
       (keyword_argument
         (identifier)
@@ -893,7 +928,9 @@ end program test
     (print_statement
       (format_identifier)
       (output_item_list
-        (string_literal)))
+        (string_literal
+          (string_literal_part)
+          (string_literal_part))))
     (end_program_statement
       (name))))
 
@@ -1065,9 +1102,12 @@ end program array_constructors
               (keyword_argument
                 (identifier)
                 (number_literal))))
-          (string_literal)
-          (string_literal)
-          (string_literal))))
+          (string_literal
+            (string_literal_part))
+          (string_literal
+            (string_literal_part))
+          (string_literal
+            (string_literal_part)))))
     (end_program_statement
       (name))))
 
@@ -1200,7 +1240,8 @@ end subroutine foo
       (concatenation_expression
         (identifier)
         (concatenation_expression
-          (string_literal)
+          (string_literal
+            (string_literal_part))
           (identifier))))
     (assignment_statement
       (call_expression

--- a/test/corpus/line_continuations.txt
+++ b/test/corpus/line_continuations.txt
@@ -17,10 +17,12 @@ end program
     (write_statement
       (unit_identifier)
       (format_identifier
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (keyword_argument
         (identifier)
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (comment)
       (keyword_argument
         (identifier)
@@ -52,11 +54,13 @@ end program
     (write_statement
       (unit_identifier)
       (format_identifier
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (comment)
       (keyword_argument
         (identifier)
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (keyword_argument
         (identifier)
         (identifier)))
@@ -145,7 +149,8 @@ end program
     (statement_label)
     (format_statement
       (transfer_items
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (end_program_statement)))
 
 ================================================================================
@@ -202,10 +207,52 @@ program test
     &hello"
   print*, "this is "&
     &"one string"
+  print*, "this is"&
+    "one string"
   print*, "this is "&
     & // "two strings"
   print*, "this is "&
     , "two strings"
+
+  print*, "this is"&
+    &""
+  print*, "this is"&
+    ""
+
+  str1 = "123&456"
+  str2 = "abc&
+         &def"
+  str3 = "with empty line: uvw&
+
+         &xyz"
+  str4 = "with trailing blanks: 987&    
+         &654"
+  str5 = "with trailing comment: ijk&  ! comment
+         &lmn"
+  str6 = "with comment: !@#&
+         ! comment
+         &$%^"
+  str6 = "with comments and empty lines: ###&
+
+         ! comment
+         ! comment
+
+         &***"
+  str7 = "without second amp: def&
+         ghi"
+  str8 = "&
+         &"
+  str9 = "&
+         ! comment
+         &"
+  strA = "&
+         &9"
+  strB = "0&
+         &"
+  strC = "&&
+         &"
+  strD = "&
+         &&"
 end program
 
 --------------------------------------------------------------------------------
@@ -217,26 +264,120 @@ end program
     (print_statement
       (format_identifier)
       (output_item_list
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (print_statement
       (format_identifier)
       (output_item_list
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (print_statement
       (format_identifier)
       (output_item_list
-        (string_literal)))
+        (string_literal
+          (string_literal_part)
+          (string_literal_part)
+          (string_literal_part))))
+    (print_statement
+      (format_identifier)
+      (output_item_list
+        (string_literal
+          (string_literal_part)
+          (string_literal_part)
+          (string_literal_part))))
     (print_statement
       (format_identifier)
       (output_item_list
         (concatenation_expression
-          (string_literal)
-          (string_literal))))
+          (string_literal
+            (string_literal_part))
+          (string_literal
+            (string_literal_part)))))
     (print_statement
       (format_identifier)
       (output_item_list
-        (string_literal)
-        (string_literal)))
+        (string_literal
+          (string_literal_part))
+        (string_literal
+          (string_literal_part))))
+    (print_statement
+      (format_identifier)
+      (output_item_list
+        (string_literal
+          (string_literal_part)
+          (string_literal_part))))
+    (print_statement
+      (format_identifier)
+      (output_item_list
+        (string_literal
+          (string_literal_part)
+          (string_literal_part))))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (string_literal_part)))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (string_literal_part)
+        (string_literal_part)))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (string_literal_part)
+        (string_literal_part)))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (string_literal_part)
+        (string_literal_part)))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (string_literal_part)
+        (comment)
+        (string_literal_part)))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (string_literal_part)
+        (comment)
+        (string_literal_part)))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (string_literal_part)
+        (comment)
+        (comment)
+        (string_literal_part)))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (string_literal_part)
+        (string_literal_part)))
+    (assignment_statement
+      (identifier)
+      (string_literal))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (comment)))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (string_literal_part)))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (string_literal_part)))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (string_literal_part)))
+    (assignment_statement
+      (identifier)
+      (string_literal
+        (string_literal_part)))
     (end_program_statement)))
 
 ================================================================================
@@ -285,6 +426,7 @@ program test
   /)
 end program test
 --------------------------------------------------------------------------------
+
 (translation_unit
   (program
     (program_statement
@@ -321,6 +463,8 @@ end program main
     (print_statement
       (format_identifier)
       (output_item_list
-        (string_literal)))
+        (string_literal
+          (string_literal_part)
+          (string_literal_part))))
     (end_program_statement
       (name))))

--- a/test/corpus/preprocessor.txt
+++ b/test/corpus/preprocessor.txt
@@ -11,7 +11,8 @@ Include directives
 
 (translation_unit
   (preproc_include
-    path: (string_literal))
+    path: (string_literal
+      (string_literal_part)))
   (preproc_include
     path: (system_lib_string))
   (preproc_include
@@ -495,7 +496,8 @@ end module foo
       (derived_type_statement
         (type_name))
       (preproc_include
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (variable_declaration
         (intrinsic_type)
         (identifier))
@@ -726,7 +728,8 @@ end program
       (identifier))
     (assignment_statement
       (identifier)
-      (string_literal))
+      (string_literal
+        (string_literal_part)))
     (select_case_statement
       (selector
         (identifier))
@@ -734,7 +737,8 @@ end program
         (identifier)
         (case_statement
           (case_value_range_list
-            (string_literal))
+            (string_literal
+              (string_literal_part)))
           (assignment_statement
             (identifier)
             (number_literal))))
@@ -744,7 +748,8 @@ end program
           (number_literal))
         (case_statement
           (case_value_range_list
-            (string_literal))
+            (string_literal
+              (string_literal_part)))
           (assignment_statement
             (identifier)
             (number_literal))))

--- a/test/corpus/regressions.txt
+++ b/test/corpus/regressions.txt
@@ -42,18 +42,21 @@ end program example_padl
       (identifier))
     (assignment_statement
       (identifier)
-      (string_literal))
+      (string_literal
+        (string_literal_part)))
     (comment)
     (print_statement
       (format_identifier
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (output_item_list
         (call_expression
           (identifier)
           (argument_list
             (identifier)
             (number_literal)
-            (string_literal)))))
+            (string_literal
+              (string_literal_part))))))
     (comment)
     (assignment_statement
       (identifier)
@@ -232,49 +235,57 @@ Multiple array assignments
         (identifier)
         (argument_list
           (identifier)))
-      (string_literal))
+      (string_literal
+        (string_literal_part)))
     (assignment_statement
       (call_expression
         (identifier)
         (argument_list
           (identifier)))
-      (string_literal))
+      (string_literal
+        (string_literal_part)))
     (assignment_statement
       (call_expression
         (identifier)
         (argument_list
           (identifier)))
-      (string_literal))
+      (string_literal
+        (string_literal_part)))
     (assignment_statement
       (call_expression
         (identifier)
         (argument_list
           (identifier)))
-      (string_literal))
+      (string_literal
+        (string_literal_part)))
     (assignment_statement
       (call_expression
         (identifier)
         (argument_list
           (identifier)))
-      (string_literal))
+      (string_literal
+        (string_literal_part)))
     (assignment_statement
       (call_expression
         (identifier)
         (argument_list
           (identifier)))
-      (string_literal))
+      (string_literal
+        (string_literal_part)))
     (assignment_statement
       (call_expression
         (identifier)
         (argument_list
           (identifier)))
-      (string_literal))
+      (string_literal
+        (string_literal_part)))
     (assignment_statement
       (call_expression
         (identifier)
         (argument_list
           (identifier)))
-      (string_literal))
+      (string_literal
+        (string_literal_part)))
     (print_statement
       (format_identifier)
       (output_item_list

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -37,34 +37,41 @@ end subroutine foo
 (translation_unit
   (comment)
   (include_statement
-    (filename))
+    (filename
+      (string_literal_part)))
   (program
     (program_statement
       (name))
     (include_statement
-      (filename))
+      (filename
+        (string_literal_part)))
     (comment)
     (include_statement
-      (filename))
+      (filename
+        (string_literal_part)))
     (interface
       (interface_statement)
       (include_statement
-        (filename))
+        (filename
+          (string_literal_part)))
       (end_interface_statement))
     (assignment_statement
       (identifier)
       (number_literal))
     (include_statement
-      (filename))
+      (filename
+        (string_literal_part)))
     (internal_procedures
       (contains_statement)
       (include_statement
-        (filename))
+        (filename
+          (string_literal_part)))
       (subroutine
         (subroutine_statement
           (name))
         (include_statement
-          (filename))
+          (filename
+            (string_literal_part)))
         (end_subroutine_statement
           (name))))
     (end_program_statement))
@@ -78,7 +85,8 @@ end subroutine foo
     (subroutine_statement
       (name))
     (include_statement
-      (filename))
+      (filename
+        (string_literal_part)))
     (comment)
     (variable_declaration
       (intrinsic_type)
@@ -413,7 +421,8 @@ END PROGRAM
         (identifier)
         (keyword_argument
           name: (identifier)
-          value: (string_literal)))
+          value: (string_literal
+            (string_literal_part))))
       declarator: (identifier))
     (variable_declaration
       type: (intrinsic_type)
@@ -715,7 +724,8 @@ END PROGRAM
           (identifier))
         (keyword_argument
           (identifier)
-          (string_literal)))
+          (string_literal
+            (string_literal_part))))
       (subroutine_call
         (identifier)
         (argument_list
@@ -1174,7 +1184,8 @@ END PROGRAM
           (call_expression
             (identifier)
             (argument_list
-              (string_literal)))))
+              (string_literal
+                (string_literal_part))))))
       (assignment_statement
         (identifier)
         (number_literal))
@@ -1622,26 +1633,34 @@ END PROGRAM
       (case_statement
         (case_value_range_list
           (extent_specifier
-            (string_literal)
-            (string_literal))
+            (string_literal
+              (string_literal_part))
+            (string_literal
+              (string_literal_part)))
           (extent_specifier
-            (string_literal)
-            (string_literal)))
+            (string_literal
+              (string_literal_part))
+            (string_literal
+              (string_literal_part))))
         (write_statement
           (unit_identifier)
           (format_identifier)
           (output_item_list
-            (string_literal))))
+            (string_literal
+              (string_literal_part)))))
       (case_statement
         (case_value_range_list
           (extent_specifier
-            (string_literal)
-            (string_literal)))
+            (string_literal
+              (string_literal_part))
+            (string_literal
+              (string_literal_part))))
         (write_statement
           (unit_identifier)
           (format_identifier)
           (output_item_list
-            (string_literal))))
+            (string_literal
+              (string_literal_part)))))
       (case_statement
         (case_value_range_list
           (identifier))
@@ -1649,14 +1668,16 @@ END PROGRAM
           (unit_identifier)
           (format_identifier)
           (output_item_list
-            (string_literal))))
+            (string_literal
+              (string_literal_part)))))
       (case_statement
         (default)
         (write_statement
           (unit_identifier)
           (format_identifier)
           (output_item_list
-            (string_literal))))
+            (string_literal
+              (string_literal_part)))))
       (end_select_statement))
     (select_case_statement
       (selector
@@ -1688,7 +1709,8 @@ END PROGRAM
     (statement_label)
     (format_statement
       (transfer_items
-        (string_literal)
+        (string_literal
+          (string_literal_part))
         (edit_descriptor)
         (edit_descriptor)))
     (statement_label)
@@ -1706,20 +1728,23 @@ END PROGRAM
         (edit_descriptor)
         (edit_descriptor)
         (edit_descriptor)
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (statement_label)
     (format_statement
       (transfer_items
         (edit_descriptor)
         (edit_descriptor)
         (edit_descriptor)
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (statement_label)
     (format_statement
       (transfer_items
         (edit_descriptor)
         (edit_descriptor)
-        (string_literal)
+        (string_literal
+          (string_literal_part))
         (edit_descriptor)
         (edit_descriptor)
         (edit_descriptor)
@@ -1802,7 +1827,8 @@ END PROGRAM
       (unit_identifier
         (identifier))
       (format_identifier
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (input_item_list
         (call_expression
           (identifier)
@@ -1814,13 +1840,15 @@ END PROGRAM
         (identifier))
       (keyword_argument
         (identifier)
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (keyword_argument
         (identifier)
         (identifier))
       (keyword_argument
         (identifier)
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (input_item_list
         (identifier)))
     (end_program_statement)))
@@ -1847,7 +1875,8 @@ END PROGRAM
     (print_statement
       (format_identifier)
       (output_item_list
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (print_statement
       (format_identifier
         (identifier))
@@ -1857,9 +1886,11 @@ END PROGRAM
         (identifier)))
     (print_statement
       (format_identifier
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (output_item_list
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (end_program_statement)))
 
 ================================================================================
@@ -1894,7 +1925,8 @@ END PROGRAM
       (type_qualifier)
       (init_declarator
         (identifier)
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (write_statement
       (unit_identifier))
     (write_statement
@@ -1915,7 +1947,8 @@ END PROGRAM
       (unit_identifier
         (identifier))
       (format_identifier
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (keyword_argument
         (identifier)
         (identifier)))
@@ -1923,7 +1956,8 @@ END PROGRAM
       (unit_identifier
         (identifier))
       (format_identifier
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (output_item_list
         (call_expression
           (identifier)
@@ -1935,35 +1969,41 @@ END PROGRAM
         (identifier))
       (keyword_argument
         (identifier)
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (keyword_argument
         (identifier)
         (identifier))
       (keyword_argument
         (identifier)
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (output_item_list
         (identifier)))
     (write_statement
       (unit_identifier
         (number_literal))
       (format_identifier
-        (string_literal))
+        (string_literal
+          (string_literal_part)))
       (output_item_list
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (write_statement
       (unit_identifier
         (number_literal))
       (format_identifier)
       (output_item_list
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (write_statement
       (unit_identifier
         (identifier))
       (format_identifier
         (identifier))
       (output_item_list
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (end_program_statement)))
 
 ================================================================================
@@ -2188,7 +2228,8 @@ end subroutine print_decorated_numbers
         (write_statement
           (unit_identifier)
           (format_identifier
-            (string_literal))
+            (string_literal
+              (string_literal_part)))
           (output_item_list
             (identifier))))
       (type_statement
@@ -2201,7 +2242,8 @@ end subroutine print_decorated_numbers
         (write_statement
           (unit_identifier)
           (format_identifier
-            (string_literal))
+            (string_literal
+              (string_literal_part)))
           (output_item_list
             (identifier))))
       (type_statement
@@ -2214,7 +2256,8 @@ end subroutine print_decorated_numbers
         (write_statement
           (unit_identifier)
           (format_identifier
-            (string_literal))
+            (string_literal
+              (string_literal_part)))
           (output_item_list
             (identifier))))
       (type_statement
@@ -2222,7 +2265,8 @@ end subroutine print_decorated_numbers
         (write_statement
           (unit_identifier)
           (format_identifier
-            (string_literal))
+            (string_literal
+              (string_literal_part)))
           (output_item_list
             (identifier))))
       (type_statement
@@ -2230,7 +2274,8 @@ end subroutine print_decorated_numbers
         (write_statement
           (unit_identifier)
           (format_identifier
-            (string_literal))
+            (string_literal
+              (string_literal_part)))
           (output_item_list
             (derived_type_member_expression
               (identifier)
@@ -2240,7 +2285,8 @@ end subroutine print_decorated_numbers
         (write_statement
           (unit_identifier)
           (format_identifier
-            (string_literal))))
+            (string_literal
+              (string_literal_part)))))
       (end_select_statement))
     (end_subroutine_statement
       (name))))
@@ -2277,26 +2323,30 @@ end program test
         (identifier))
       (keyword_argument
         (identifier)
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (close_statement
       (unit_identifier
         (identifier))
       (keyword_argument
         (identifier)
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (open_statement
       (keyword_argument
         (identifier)
         (identifier))
       (keyword_argument
         (identifier)
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (close_statement
       (unit_identifier
         (identifier))
       (keyword_argument
         (identifier)
-        (string_literal)))
+        (string_literal
+          (string_literal_part))))
     (open_statement
       (unit_identifier
         (number_literal)))
@@ -2355,7 +2405,8 @@ end subroutine assumed_rank
           (unit_identifier)
           (format_identifier)
           (output_item_list
-            (string_literal))))
+            (string_literal
+              (string_literal_part)))))
       (rank_statement
         (case_value_range_list
           (number_literal))
@@ -2363,7 +2414,8 @@ end subroutine assumed_rank
           (unit_identifier)
           (format_identifier)
           (output_item_list
-            (string_literal))))
+            (string_literal
+              (string_literal_part)))))
       (rank_statement
         (case_value_range_list
           (number_literal))
@@ -2371,11 +2423,13 @@ end subroutine assumed_rank
           (unit_identifier)
           (format_identifier)
           (output_item_list
-            (string_literal))))
+            (string_literal
+              (string_literal_part)))))
       (rank_statement
         (default)
         (stop_statement
-          (string_literal)))
+          (string_literal
+            (string_literal_part))))
       (end_select_statement))
     (select_rank_statement
       (block_label_start_expression)
@@ -2388,7 +2442,8 @@ end subroutine assumed_rank
           (unit_identifier)
           (format_identifier)
           (output_item_list
-            (string_literal))))
+            (string_literal
+              (string_literal_part)))))
       (end_select_statement
         (block_label)))
     (end_subroutine_statement
@@ -2673,7 +2728,8 @@ end program test
           (identifier)
           (type_member))
         (data_value
-          (string_literal))))
+          (string_literal
+            (string_literal_part)))))
     (data_statement
       (data_set
         (identifier)
@@ -2682,7 +2738,8 @@ end program test
             (identifier)
             (argument_list
               (number_literal)
-              (string_literal))))))
+              (string_literal
+                (string_literal_part)))))))
     (data_statement
       (data_set
         (implied_do_loop_expression
@@ -2826,7 +2883,8 @@ end program
         (parenthesized_expression
           (number_literal))))
     (file_position_statement
-      (string_literal))
+      (string_literal
+        (string_literal_part)))
     (end_program_statement)))
 
 ================================================================================
@@ -3067,7 +3125,8 @@ Statement Functions (Obsolescent)
         (number_literal)))
     (assignment_statement
       (identifier)
-      (string_literal))
+      (string_literal
+        (string_literal_part)))
     (end_subroutine_statement
       (name))))
 


### PR DESCRIPTION
I have worked on the idea suggested in #193 to solve the comment within string literal problem and also to identify parts of the string. I already experimented a bit with the extended tree using it for syntax highlighting and indentation of multiline string.

A string_literal is now parsed as a sequence like

```
(string_literal "\"" (string_literal_part) "\\" (string_literal) &
                (comment)  (comment) & (string_literal_part) "\"")
```

Double (double or single) quotes are parsed with escape node `"\\"` for the first quote character, and `(string_literal_part)` representing the second quote character. I am not convinced to really use `"\\"` as node name for the escape quote, as I sometimes struggle with whether to use one, two or four backslashes. But I would like to keep a separate anonymous or named node type for this, as it makes identifying escaped quotes easy. 

The true content of a string_literal can be constructed as concatenation of all `(string_literal_part)` children. Including `"\\"` in the concatenation as well yields the content as found in the fortran source.

The only quirk is that a string like `"012&abc"` needs to be broken into two `(string_literal_part)`, as the look-ahead and commit mechanics of the scanner dictates to emit a first `(string_literal_part)` for "012" and then use possibly extensive look-ahead to decide whether the ampersand is a continuation symbol.

The commit adds four new external tokens, a new scanner state `in_string` to track whether the scanner is within a string, with a continuation within a string and escaped quotes.

Examples can be found in the commit in the corpus. Unfortunately, the files in the corpus requires rather extensive updates, as any `(string_literal)` now becomes at least `(string_literal (string_literal_part))` and thus needs to be updated.

_Edit: Some fixes and quotes added._